### PR TITLE
fix(swman): prevent unwanted package installations during check operations

### DIFF
--- a/src/dotfiles/console_output.py
+++ b/src/dotfiles/console_output.py
@@ -1,0 +1,219 @@
+"""
+Console output and logging helper classes for dotfiles Python tools.
+
+Provides Rich-based console output and logging helper abstractions.
+"""
+
+import structlog
+from rich.console import Console
+from rich.progress import (
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+    BarColumn,
+    TaskProgressColumn,
+)
+from rich.table import Table
+from rich import print as rich_print
+
+
+class LoggingHelpers:
+    """
+    Helper class for common logging operations that takes a logger instance.
+
+    Follows Hynek's principle of explicit dependency injection instead of global state.
+    """
+
+    def __init__(self, logger: structlog.BoundLogger):
+        self.logger = logger
+
+    def log_error(self, message: str, **context) -> None:
+        """Log error with context."""
+        self.logger.error(message, **context)
+
+    def log_warning(self, message: str, **context) -> None:
+        """Log warning with context."""
+        self.logger.warning(message, **context)
+
+    def log_info(self, message: str, **context) -> None:
+        """Log info with context."""
+        self.logger.info(message, **context)
+
+    def log_progress(self, message: str, **context) -> None:
+        """Log progress/status information."""
+        self.logger.info("progress", message=message, **context)
+
+    def log_subprocess_result(
+        self, description: str, command: list, result, **context
+    ) -> None:
+        """
+        Log comprehensive subprocess execution details.
+
+        Args:
+            description: Human readable description of the command
+            command: The command that was executed
+            result: subprocess.CompletedProcess result
+            **context: Additional context
+        """
+        base_data = {
+            "operation": "subprocess",
+            "description": description,
+            "command": command,
+            "returncode": result.returncode,
+            **context,
+        }
+
+        if result.returncode == 0:
+            self.logger.info("subprocess_success", **base_data)
+        else:
+            self.logger.error("subprocess_failed", **base_data)
+
+        # Always log stdout/stderr for debugging regardless of success
+        if result.stdout:
+            self.logger.debug(
+                "subprocess_stdout",
+                description=description,
+                stdout=result.stdout.strip(),
+            )
+
+        if result.stderr:
+            self.logger.debug(
+                "subprocess_stderr",
+                description=description,
+                stderr=result.stderr.strip(),
+            )
+
+    def log_exception(self, exception: Exception, context_msg: str, **context) -> None:
+        """
+        Log exception with full context and traceback.
+
+        Args:
+            exception: The exception that occurred
+            context_msg: Human readable context about what was happening
+            **context: Additional context
+        """
+        self.logger.error(
+            "exception_occurred",
+            context=context_msg,
+            exception_type=type(exception).__name__,
+            exception_message=str(exception),
+            **context,
+        )
+
+    def log_file_operation(
+        self, operation: str, path: str, success: bool, **context
+    ) -> None:
+        """
+        Log file system operations.
+
+        Args:
+            operation: Type of operation (create, link, delete, etc.)
+            path: File path involved
+            success: Whether operation succeeded
+            **context: Additional context
+        """
+        level = "info" if success else "error"
+        getattr(self.logger, level)(
+            "file_operation", operation=operation, path=path, success=success, **context
+        )
+
+    def log_package_operation(
+        self, manager: str, operation: str, packages: list, success: bool, **context
+    ) -> None:
+        """
+        Log package manager operations.
+
+        Args:
+            manager: Package manager name (pacman, yay, apt, etc.)
+            operation: Operation type (install, update, check, etc.)
+            packages: List of packages involved
+            success: Whether operation succeeded
+            **context: Additional context
+        """
+        level = "info" if success else "error"
+        getattr(self.logger, level)(
+            "package_operation",
+            manager=manager,
+            operation=operation,
+            package_count=len(packages),
+            packages=packages[:10],  # Limit to first 10 for readability
+            success=success,
+            **context,
+        )
+
+
+# Global console instance for consistent styling
+console = Console()
+
+
+class ConsoleOutput:
+    """
+    Rich-based console output abstraction that replaces print statements.
+
+    Provides consistent styling and formatting across all tools.
+    """
+
+    def __init__(self, verbose: bool = True, quiet: bool = False):
+        self.verbose = verbose
+        self.quiet = quiet
+        self.console = console
+
+    def status(self, message: str, emoji: str = "🔍") -> None:
+        """Display a status message with emoji."""
+        if not self.quiet:
+            self.console.print(f"{emoji} {message}")
+
+    def success(self, message: str, emoji: str = "✅") -> None:
+        """Display a success message."""
+        if not self.quiet:
+            self.console.print(f"{emoji} {message}", style="green")
+
+    def error(self, message: str, emoji: str = "❌") -> None:
+        """Display an error message."""
+        if not self.quiet:
+            self.console.print(f"{emoji} {message}", style="red")
+
+    def warning(self, message: str, emoji: str = "⚠️") -> None:
+        """Display a warning message."""
+        if not self.quiet:
+            self.console.print(f"{emoji} {message}", style="yellow")
+
+    def info(self, message: str, emoji: str = "💡") -> None:
+        """Display an info message."""
+        if not self.quiet and self.verbose:
+            self.console.print(f"{emoji} {message}", style="blue")
+
+    def header(self, title: str, emoji: str = "📊") -> None:
+        """Display a section header."""
+        if not self.quiet:
+            self.console.print(f"\n{emoji} {title}", style="bold cyan")
+            self.console.print("=" * (len(title) + 3))
+
+    def table(self, title: str, columns: list, rows: list, emoji: str = "📋") -> None:
+        """Display a formatted table."""
+        if not self.quiet:
+            table = Table(title=f"{emoji} {title}")
+
+            for column in columns:
+                table.add_column(column, style="cyan")
+
+            for row in rows:
+                table.add_row(*[str(cell) for cell in row])
+
+            self.console.print(table)
+
+    def progress_context(self):
+        """Return a Rich progress context for long operations."""
+        return Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            TaskProgressColumn(),
+            console=self.console,
+            disable=self.quiet,
+        )
+
+    def json(self, data) -> None:
+        """Pretty print JSON data."""
+        if not self.quiet:
+            rich_print(data)

--- a/src/dotfiles/init.py
+++ b/src/dotfiles/init.py
@@ -1,0 +1,1596 @@
+from datetime import datetime
+import os
+from os.path import abspath, exists, expanduser
+import socket
+import subprocess
+import sys
+import time
+import traceback
+import urllib.request
+import urllib.error
+
+import click
+from .logging_config import setup_logging, bind_context
+from .console_output import LoggingHelpers, ConsoleOutput
+
+
+def expand(path):
+    return abspath(expanduser(path))
+
+
+def check_systemd_service_status(service):
+    """Check if a systemd service is enabled and active"""
+    try:
+        # Check if service is enabled
+        enabled_result = subprocess.run(
+            ["systemctl", "is-enabled", service], capture_output=True, text=True
+        )
+        is_enabled = (
+            enabled_result.returncode == 0 and "enabled" in enabled_result.stdout
+        )
+
+        # Check if service is active
+        active_result = subprocess.run(
+            ["systemctl", "is-active", service], capture_output=True, text=True
+        )
+        is_active = active_result.returncode == 0 and "active" in active_result.stdout
+
+        return is_enabled, is_active
+    except Exception:
+        # If systemctl check fails, assume service needs setup
+        return False, False
+
+
+def ensure_path(path):
+    if not exists(expand(path)):
+        os.makedirs(expand(path))
+
+
+class Linux:
+    config_dirs = [
+        ("alacritty", "alacritty"),
+        ("direnv", "direnv"),
+        ("fish", "fish"),
+        ("lazy_nvim", "nvim"),
+        ("tmux", "tmux"),
+        ("byobu", "byobu"),
+        ("git", "git"),
+    ]
+
+    ssh_key_email = "sshkeys@patrick-gerken.de"
+
+    environment_specific = {
+        "config_dirs": {
+            "private": [
+                ("irssi", "irssi"),
+            ]
+        },
+        "ssh_key_email": {"work": "patrick.gerken@zumtobelgroup.com"},
+    }
+
+    def __init__(self, environment="minimal", no_remote_mode=False):
+        self.environment = environment
+        self.no_remote_mode = no_remote_mode
+
+    def run_command_with_error_handling(
+        self,
+        command,
+        logger: LoggingHelpers,
+        description="Command",
+        timeout=300,
+        **kwargs,
+    ):
+        """Run a subprocess command with comprehensive error handling and logging"""
+        logger.log_info(
+            "command_starting",
+            description=description,
+            command=command,
+            timeout=timeout,
+        )
+
+        try:
+            result = subprocess.run(
+                command,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                **kwargs,
+            )
+
+            # Use the new comprehensive subprocess logging
+            logger.log_subprocess_result(description, command, result)
+            return result
+
+        except subprocess.TimeoutExpired:
+            logger.log_exception(
+                "command_timeout",
+                description=description,
+                command=command,
+                timeout=timeout,
+            )
+            print(f"❌ ERROR: {description} timed out after {timeout} seconds")
+            print(f"🔍 Command: {' '.join(command)}")
+            raise
+        except subprocess.CalledProcessError as e:
+            logger.log_exception(
+                "command_failed",
+                description=description,
+                command=command,
+                returncode=e.returncode,
+                stdout=e.stdout,
+                stderr=e.stderr,
+            )
+            print(f"❌ ERROR: {description} failed: {e}")
+            print(f"🔍 Command: {' '.join(command)}")
+            if e.stdout:
+                print(f"📄 STDOUT:\n{e.stdout}")
+            if e.stderr:
+                print(f"📄 STDERR:\n{e.stderr}")
+            raise
+        except Exception as e:
+            logger.log_exception(
+                e, f"Unexpected error running {description}", command=command
+            )
+            print(f"❌ ERROR: Unexpected error running {description}: {e}")
+            print(f"🔍 Command: {' '.join(command)}")
+            raise
+
+    def install_dependencies(self, logger: LoggingHelpers):
+        """Install NVM and Pyenv with proper error handling"""
+        logger.log_progress("starting_dependency_installation")
+
+        # Install NVM
+        nvm_path = expand("~/.local/share/nvm")
+        logger.log_info("checking_nvm_installation", nvm_path=nvm_path)
+
+        if not exists(nvm_path):
+            nvm_script = "doesnotexist"
+            try:
+                logger.log_progress("installing_nvm")
+                print("Installing NVM...")
+                nvm_script = expand("./install_scripts/install_nvm.sh")
+
+                if not exists(nvm_script):
+                    logger.log_error("nvm_script_not_found", script_path=nvm_script)
+                    print("❌ ERROR: NVM installation script not found")
+                    print(f"💡 Expected: {nvm_script}")
+                    raise FileNotFoundError(f"NVM script not found: {nvm_script}")
+
+                logger.log_info("executing_nvm_script", script=nvm_script)
+                result = subprocess.run(
+                    ["/usr/bin/bash", nvm_script],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=300,  # 5 minute timeout
+                )
+                logger.log_subprocess_result(
+                    "NVM installation", ["/usr/bin/bash", nvm_script], result
+                )
+                logger.log_progress("nvm_installed_successfully")
+                print("✅ NVM installed successfully")
+
+            except subprocess.TimeoutExpired as e:
+                logger.log_exception(e, "nvm_installation_timeout", timeout=300)
+                print("❌ ERROR: NVM installation timed out (network issues?)")
+                print("💡 Try: Check internet connection and run again")
+                raise
+            except subprocess.CalledProcessError as e:
+                logger.log_exception(
+                    e,
+                    "nvm_installation_failed",
+                    returncode=e.returncode,
+                    stdout=e.stdout,
+                    stderr=e.stderr,
+                )
+                print(
+                    f"❌ ERROR: NVM installation failed with exit code {e.returncode}"
+                )
+                if e.stderr:
+                    print(f"💡 Error output: {e.stderr}")
+                print("💡 Try: Check network connection and script permissions")
+                raise
+            except FileNotFoundError as e:
+                logger.log_exception(
+                    e, "NVM installation file not found", script_path=nvm_script
+                )
+                if "/usr/bin/bash" in str(e):
+                    print("❌ ERROR: Bash not found at /usr/bin/bash")
+                    print("💡 Try: Install bash or update the script")
+                else:
+                    print(f"❌ ERROR: {e}")
+                raise
+        else:
+            logger.log_info("nvm_already_installed", nvm_path=nvm_path)
+            print("✅ NVM already installed")
+
+        # Install Pyenv
+        pyenv_path = expand("~/.config/pyenv")
+        if not exists(pyenv_path):
+            try:
+                print("Installing Pyenv...")
+                pyenv_script = expand("./install_scripts/install_pyenv.sh")
+                if not exists(pyenv_script):
+                    print("❌ ERROR: Pyenv installation script not found")
+                    print(f"💡 Expected: {pyenv_script}")
+                    raise FileNotFoundError(f"Pyenv script not found: {pyenv_script}")
+
+                subprocess.run(
+                    ["/usr/bin/bash", pyenv_script],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=300,
+                )
+                print("✅ Pyenv installed successfully")
+            except subprocess.TimeoutExpired:
+                print("❌ ERROR: Pyenv installation timed out")
+                print("💡 Try: Check internet connection and run again")
+                raise
+            except subprocess.CalledProcessError as e:
+                print(
+                    f"❌ ERROR: Pyenv installation failed with exit code {e.returncode}"
+                )
+                if e.stderr:
+                    print(f"💡 Error output: {e.stderr}")
+                raise
+            except FileNotFoundError as e:
+                print(f"❌ ERROR: {e}")
+                raise
+        else:
+            print("✅ Pyenv already installed")
+
+    def link_configs(self, logger: LoggingHelpers):
+        """Create symlinks with comprehensive error handling"""
+        # Ensure ~/.config exists
+        config_base_dir = expand("~/.config")
+        try:
+            ensure_path(config_base_dir)
+        except OSError as e:
+            print(f"❌ ERROR: Cannot create ~/.config directory: {e}")
+            print("💡 Try: Check home directory permissions")
+            raise
+
+        for config_dir_src, config_dir_target in (
+            self.config_dirs
+            + self.environment_specific["config_dirs"].get(self.environment, [])
+        ):
+            target_path = expand(f"~/.config/{config_dir_target}")
+            source_path = expand(f"./{config_dir_src}")
+
+            try:
+                # Verify source exists
+                if not exists(source_path):
+                    print(f"❌ ERROR: Source directory {source_path} does not exist")
+                    print(f"💡 Expected config directory: {config_dir_src}")
+                    continue
+
+                if not exists(target_path):
+                    try:
+                        os.symlink(source_path, target_path)
+                        print(f"✅ Linked {config_dir_target}")
+                        self.restart_required = True
+                    except OSError as e:
+                        if e.errno == 13:  # Permission denied
+                            print(
+                                f"❌ ERROR: Permission denied creating symlink for {config_dir_target}"
+                            )
+                            print(
+                                "💡 Try: Check ~/.config directory ownership and permissions"
+                            )
+                        elif e.errno == 17:  # File exists (race condition)
+                            print(
+                                f"⚠️  WARNING: {config_dir_target} was created by another process"
+                            )
+                        elif e.errno == 30:  # Read-only file system
+                            print(
+                                f"❌ ERROR: Cannot create symlink on read-only filesystem for {config_dir_target}"
+                            )
+                        else:
+                            print(
+                                f"❌ ERROR: Failed to create symlink for {config_dir_target}: {e}"
+                            )
+                        continue
+                else:
+                    # Check if it's a directory or symlink to another location
+                    if os.path.isdir(target_path):
+                        if os.path.islink(target_path):
+                            # It's a symlink to a directory
+                            try:
+                                current_target = os.readlink(target_path)
+                                expected_target = source_path
+                                if current_target != expected_target:
+                                    print(
+                                        f"⚠️  WARNING: {config_dir_target} is linked to {current_target}, "
+                                        f"but should be linked to {expected_target}"
+                                    )
+                                else:
+                                    print(
+                                        f"✅ {config_dir_target} is already correctly linked"
+                                    )
+                            except OSError as e:
+                                print(
+                                    f"⚠️  WARNING: Could not read symlink for {config_dir_target}: {e}"
+                                )
+                        else:
+                            # It's a regular directory
+                            print(
+                                f"⚠️  WARNING: {config_dir_target} exists as a directory, "
+                                f"but should be a symlink to {source_path}"
+                            )
+                    else:
+                        # It's a file (not a directory)
+                        print(
+                            f"⚠️  WARNING: {config_dir_target} exists as a file, "
+                            f"but should be a symlink to {source_path}"
+                        )
+            except Exception as e:
+                print(f"❌ ERROR: Unexpected error processing {config_dir_target}: {e}")
+                continue
+
+    def validate_git_credential_helper(self, logger: LoggingHelpers):
+        """Validate that git credential helper is properly configured"""
+        try:
+            # Check if libsecret binary exists
+            libsecret_path = "/usr/lib/git-core/git-credential-libsecret"
+            if not exists(libsecret_path):
+                print(
+                    f"⚠️  WARNING: git-credential-libsecret not found at {libsecret_path}"
+                )
+                print("💡 Try: Install libsecret package")
+                return False
+
+            # Check if libsecret binary is executable
+            if not os.access(libsecret_path, os.X_OK):
+                print("⚠️  WARNING: git-credential-libsecret is not executable")
+                print("💡 Try: chmod +x /usr/lib/git-core/git-credential-libsecret")
+                return False
+
+            # Test if credential helper responds
+            try:
+                _ = subprocess.run(
+                    [libsecret_path],
+                    input="",
+                    text=True,
+                    capture_output=True,
+                    timeout=5,
+                )
+                # libsecret helper should exit cleanly when given empty input
+                print("✅ Git credential helper (libsecret) is properly configured")
+                return True
+            except subprocess.TimeoutExpired:
+                print("⚠️  WARNING: Git credential helper test timed out")
+                return False
+            except Exception as e:
+                print(f"⚠️  WARNING: Error testing git credential helper: {e}")
+                return False
+
+        except Exception as e:
+            print(f"❌ ERROR: Failed to validate git credential helper: {e}")
+            return False
+
+    def setup_shell(self, logger: LoggingHelpers):
+        # Check current user's default shell
+        try:
+            current_shell = os.environ.get("SHELL", "")
+            if not current_shell.endswith("/fish"):
+                # Double-check by reading from /etc/passwd
+                import pwd
+
+                user_entry = pwd.getpwuid(os.getuid())
+                if not user_entry.pw_shell.endswith("/fish"):
+                    print(f"Changing shell from {user_entry.pw_shell} to fish")
+                    self.self.run_command_with_error_handling(
+                        ["chsh", "-s", "/usr/bin/fish"], logger, "Change shell to fish"
+                    )
+                    self.restart_required = True
+                else:
+                    print("Shell is already set to fish")
+            else:
+                print("Shell is already set to fish")
+        except Exception as e:
+            print(f"Warning: Could not check/change shell: {e}")
+
+    def link_accounts(self, logger: LoggingHelpers):
+        if self.no_remote_mode:
+            print("No-remote mode: Skipping GitHub and SSH key setup")
+            return
+
+        try:
+            result = self.run_command_with_error_handling(
+                ["/usr/bin/gh", "auth", "status"], logger, "Check GitHub auth status"
+            )
+            if "Logged in" not in result.stdout:
+                # Interactive command - don't capture output
+                subprocess.run(["/usr/bin/gh", "auth", "login"])
+                self.run_command_with_error_handling(
+                    [
+                        "gh",
+                        "auth",
+                        "refresh",
+                        "-h",
+                        "github.com",
+                        "-s",
+                        "admin:public_key",
+                    ],
+                    logger,
+                    "Refresh GitHub auth",
+                )
+        except subprocess.CalledProcessError:
+            print("GitHub CLI not authenticated, running login...")
+            subprocess.run(["/usr/bin/gh", "auth", "login"])
+            self.run_command_with_error_handling(
+                ["gh", "auth", "refresh", "-h", "github.com", "-s", "admin:public_key"],
+                logger,
+                "Refresh GitHub auth",
+            )
+
+        # Use permanent SSH key based on hostname and environment
+        key_suffix = f"{socket.gethostname()}_{self.environment}"
+        current_key = expand(f"~/.ssh/id_ed25519_{key_suffix}")
+
+        if not exists(current_key):
+            ssh_key_email = self.environment_specific["ssh_key_email"].get(
+                self.environment, self.ssh_key_email
+            )
+            self.run_command_with_error_handling(
+                [
+                    "ssh-keygen",
+                    "-t",
+                    "ed25519",
+                    "-C",
+                    f"'Patrick Gerken {socket.gethostname()} {ssh_key_email} {self.environment}'",
+                    "-f",
+                    current_key,
+                    "-N",
+                    "",  # No passphrase
+                ],
+                logger,
+                "Generate SSH key",
+            )
+            self.run_command_with_error_handling(
+                ["ssh-add", current_key], logger, "Add SSH key to agent"
+            )
+            key_name = f'"{socket.gethostname()} {self.environment}"'
+            self.run_command_with_error_handling(
+                ["/usr/bin/gh", "ssh-key", "add", f"{current_key}.pub", "-t", key_name],
+                logger,
+                "Add SSH key to GitHub",
+            )
+
+        if self.environment in ["private"]:
+            try:
+                result = self.run_command_with_error_handling(
+                    ["tailscale", "status"], logger, "Check Tailscale status"
+                )
+                # Check if we have an IP address (connected) or if we're logged out
+                if "100." not in result.stdout or "Logged out" in result.stdout:
+                    print("Tailscale not connected, running setup...")
+                    # Use 'tailscale up' for locked tailnets instead of login
+                    subprocess.run(["sudo", "tailscale", "up", "--operator=do3cc"])
+                else:
+                    print("✅ Tailscale is connected")
+            except subprocess.CalledProcessError:
+                print("Tailscale not available, running setup...")
+                subprocess.run(["sudo", "tailscale", "up", "--operator=do3cc"])
+
+
+class Arch(Linux):
+    aur_packages = [
+        "google-java-format",  # Java formatting tool
+        "nodejs-markdown-toc",  # TOC Generator in javascript
+        "tmux-plugin-manager",  # Tmux Plugin Manager (TPM)
+    ]
+    pacman_packages = [
+        "ast-grep",  # structural code search tool
+        "bat",  # syntax highlighted cat alternative
+        "byobu",  # terminal multiplexer frontend
+        "direnv",  # environment variable manager
+        "eza",  # modern ls replacement
+        "fd",  # fast find replacement
+        "fish",  # friendly interactive shell
+        "git",  # version control system
+        "github-cli",  # GitHub command line interface
+        "glab",  # GitLab command line interface
+        "htop",  # interactive process viewer
+        "jdk-openjdk",  # Java development kit
+        "jq",  # JSON command line processor
+        "texlive-latex",  # for markdown rendering
+        "lazygit",  # git cli used by lazy vim
+        "less",  # terminal pager
+        "lua51",  # Lua scripting language
+        "luarocks",  # Lua package manager
+        "man-db",  # manual page database
+        "markdownlint-cli2",  # linter for markdown
+        "mermaid-cli",  # diagram generation tool
+        "neovim",  # modern Vim text editor
+        "nmap",  # network discovery and scanning
+        "npm",  # Node.js package manager
+        "prettier",  # code formatter for JS/TS/JSON/YAML/MD
+        "python-pip",  # Global pip
+        "rsync",  # file synchronization tool
+        "shfmt",  # shell script formatter
+        "starship",  # cross-shell prompt
+        "stylua",  # Lua code formatter
+        "tectonic",  # LaTeX engine
+        "the_silver_searcher",  # fast text search tool
+        "tig",  # text-mode Git interface
+        "tealdeer",  # fast tldr client
+        "tree-sitter-cli",  # parser generator tool
+        "uv",  # fast Python package manager
+        "wget",  # web file downloader
+        "yarn",  # Node.js package manager
+    ]
+
+    environment_specific = {
+        "aur_packages": {
+            "private": [
+                "hyprshot",  # Hyprland screenshot tool
+            ]
+        },
+        "pacman_packages": {
+            "private": [
+                "bitwarden",  # password manager
+                "firefox",  # web browser
+                "ghostscript",  # PostScript and PDF interpreter
+                "imagemagick",  # image manipulation toolkit
+                "noto-fonts-emoji",  # emoji font collection
+                "otf-font-awesome",  # icon font
+                "python-gobject",  # Python GObject bindings
+                "tailscale",  # mesh VPN service
+            ]
+        },
+        "systemd_services_to_enable": {
+            "private": [
+                "tailscaled",
+            ]
+        },
+        "config_dirs": Linux.environment_specific["config_dirs"],
+        "ssh_key_email": Linux.environment_specific["ssh_key_email"],
+    }
+    systemd_services_to_enable = []
+
+    def check_packages_installed(self, packages, logger: LoggingHelpers):
+        """Check which packages are already installed via pacman"""
+        logger.log_info(
+            "checking_pacman_packages",
+            package_count=len(packages),
+            packages=packages[:10],
+        )
+
+        if not packages:
+            logger.log_info("no_packages_to_check")
+            return [], []
+
+        try:
+            result = subprocess.run(
+                ["pacman", "-Q"] + packages, capture_output=True, text=True
+            )
+            logger.log_subprocess_result(
+                "bulk pacman package check", ["pacman", "-Q"] + packages[:5], result
+            )
+
+            # pacman -Q returns 0 if all packages are installed
+            if result.returncode == 0:
+                logger.log_info("all_packages_installed", packages=packages)
+                return packages, []
+
+            # Some packages are missing, check individually
+            logger.log_info(
+                "checking_packages_individually", package_count=len(packages)
+            )
+            installed = []
+            missing = []
+
+            for package in packages:
+                check_result = subprocess.run(
+                    ["pacman", "-Q", package], capture_output=True, text=True
+                )
+                if check_result.returncode == 0:
+                    installed.append(package)
+                else:
+                    missing.append(package)
+
+            logger.log_info(
+                "package_check_completed",
+                installed_count=len(installed),
+                missing_count=len(missing),
+                installed=installed[:10],
+                missing=missing[:10],
+            )
+            return installed, missing
+        except Exception as e:
+            logger.log_exception(e, "pacman package check failed", packages=packages)
+            # If pacman check fails, assume all packages need installation
+            return [], packages
+
+    def should_update_system(self):
+        """Check if system update should be performed (not done in last 24 hours)"""
+        update_marker = expand("~/.cache/dotfiles_last_update")
+
+        if not exists(update_marker):
+            return True
+
+        try:
+            with open(update_marker, "r") as f:
+                last_update_str = f.read().strip()
+
+            last_update = datetime.fromisoformat(last_update_str)
+            time_since_update = datetime.now() - last_update
+
+            # Update if more than 24 hours have passed
+            return time_since_update.total_seconds() > 24 * 60 * 60
+
+        except (ValueError, OSError):
+            # If we can't read/parse the file, assume we should update
+            return True
+
+    def mark_system_updated(self):
+        """Mark that system update was performed"""
+        update_marker = expand("~/.cache/dotfiles_last_update")
+
+        # Ensure cache directory exists
+        cache_dir = os.path.dirname(update_marker)
+        os.makedirs(cache_dir, exist_ok=True)
+
+        try:
+            with open(update_marker, "w") as f:
+                f.write(datetime.now().isoformat())
+        except OSError as e:
+            print(f"⚠️  WARNING: Could not write update marker: {e}")
+
+    def update_system(self, logger: LoggingHelpers):
+        """Perform system update if needed"""
+        if self.no_remote_mode:
+            print("No-remote mode: Skipping system updates")
+            return
+
+        if not self.should_update_system():
+            print("✅ System updated within last 24 hours, skipping update")
+            return
+
+        # Check if updates are available (non-sudo command)
+        try:
+            result = subprocess.run(
+                ["checkupdates"], capture_output=True, text=True, timeout=30
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                updates = result.stdout.strip().split("\n")
+                print(f"🔄 Found {len(updates)} system updates available")
+                # Use streaming subprocess for system update to show progress
+                # System updates can take 10-15 minutes and users need to see progress
+                result = subprocess.run(
+                    ["sudo", "pacman", "-Syu", "--noconfirm"],
+                    check=True,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    timeout=1800,  # 30 minutes for system updates (can be large)
+                )
+                logger.log_subprocess_result(
+                    "System update",
+                    ["sudo", "pacman", "-Syu", "--noconfirm"],
+                    result,
+                )
+                print("✅ System update completed successfully")
+                self.mark_system_updated()
+            else:
+                print("✅ No system updates available")
+                self.mark_system_updated()
+        except FileNotFoundError:
+            # checkupdates not available, fallback to regular update
+            print("🔄 Updating system packages...")
+            # Use streaming subprocess for fallback system update to show progress
+            result = subprocess.run(
+                ["sudo", "pacman", "-Syu", "--noconfirm"],
+                check=True,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=1800,  # 30 minutes for system updates (can be large)
+            )
+            logger.log_subprocess_result(
+                "System update", ["sudo", "pacman", "-Syu", "--noconfirm"], result
+            )
+            print("✅ System update completed successfully")
+            self.mark_system_updated()
+        except Exception:
+            print("💡 Try: Run 'sudo pacman -Syu' manually to check for issues")
+            raise
+
+    def install_dependencies(self, logger: LoggingHelpers):
+        """Install packages with retry logic and comprehensive error handling"""
+
+        # Perform system update if needed
+        self.update_system(logger)
+
+        def pacman(*args, **kwargs):
+            """
+            Execute pacman commands with real-time output, error handling, and retry logic.
+
+            Key improvements implemented here:
+            1. Real-time output streaming (removed capture_output=True)
+            2. Reduced timeout for faster failure detection
+            3. Comprehensive error handling with retries
+            4. Consistent timeout with APT operations (600s)
+
+            Arch Linux advantages:
+            - Uses --noconfirm to prevent interactive prompts (no timezone issues)
+            - No environment variable complications like APT
+            - Generally faster package operations than APT
+            """
+            max_retries = 3
+            for attempt in range(max_retries):
+                try:
+                    # Real-time output streaming configuration
+                    #
+                    # Previous problem: capture_output=True hid all pacman progress from users.
+                    # Users only saw "Installing X packages..." with no visible progress.
+                    #
+                    # Solution: Remove capture_output=True to show real-time package installation.
+                    # Still capture stderr for error handling while stdout flows to terminal.
+                    #
+                    # Timeout reduced from 1800s (30min) to 600s (10min) for consistency with APT
+                    # and faster failure detection in CI environments.
+                    result = subprocess.run(
+                        ["sudo", "pacman"] + list(args),
+                        check=True,
+                        stderr=subprocess.PIPE,  # Capture stderr for error analysis
+                        text=True,
+                        timeout=600,  # 10 minute timeout (was 30 min - align with APT)
+                        **kwargs,
+                    )
+                    # Log successful command for debugging (matching APT implementation)
+                    logger.log_subprocess_result(
+                        "Pacman command", ["sudo", "pacman"] + list(args), result
+                    )
+                    return result
+                except subprocess.TimeoutExpired:
+                    print(
+                        f"❌ Package installation timed out (attempt {attempt + 1}/{max_retries})"
+                    )
+                    if attempt == max_retries - 1:
+                        print(
+                            "💡 Try: Check internet connection or use different mirror"
+                        )
+                        raise
+                    print("🔄 Retrying in 10 seconds...")
+                    time.sleep(10)
+                except subprocess.CalledProcessError as e:
+                    print(f"❌ ERROR: Package installation failed: {e}")
+                    print(f"🔍 Command: sudo pacman {' '.join(args)}")
+                    if e.stdout:
+                        print(f"📄 STDOUT:\n{e.stdout}")
+                    if e.stderr:
+                        print(f"📄 STDERR:\n{e.stderr}")
+
+                    # Provide specific advice based on error
+                    stderr_lower = e.stderr.lower() if e.stderr else ""
+                    if "conflict" in stderr_lower:
+                        print(
+                            "💡 Try: Resolve conflicts manually or update system first"
+                        )
+                    elif "not found" in stderr_lower:
+                        print("💡 Try: Update package databases with 'pacman -Sy'")
+                    elif (
+                        "permission denied" in stderr_lower
+                        or "password" in stderr_lower
+                    ):
+                        print("💡 Try: Configure sudo or run in interactive terminal")
+                    else:
+                        print("💡 Try: Check the error details above")
+                    raise
+
+        try:
+            # Check and install base packages
+            base_packages = ["git", "base-devel"]
+            print("Checking base development tools...")
+            installed, missing = self.check_packages_installed(base_packages, logger)
+
+            if installed:
+                print(f"✅ Already installed: {', '.join(installed)}")
+
+            if missing:
+                print(
+                    f"Installing {len(missing)} base development tools: {', '.join(missing)}"
+                )
+                pacman("-S", "--needed", "--noconfirm", *missing)
+                print("✅ Base development tools installed")
+                self.restart_required = True
+            else:
+                print("✅ All base development tools already installed")
+
+            # Create projects directory safely
+            projects_dir = expand("~/projects")
+            try:
+                ensure_path(projects_dir)
+            except OSError as e:
+                print(f"❌ ERROR: Cannot create projects directory: {e}")
+                print("💡 Try: Check home directory permissions")
+                raise
+
+            # Check if yay is already installed system-wide
+            yay_installed = False
+            try:
+                subprocess.run(["yay", "--version"], capture_output=True, check=True)
+                yay_installed = True
+                print("✅ Yay AUR helper already installed")
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                yay_installed = False
+
+            # Install yay if not available
+            if not yay_installed:
+                yay_dir = expand("~/projects/yay-bin")
+                if not exists(yay_dir):
+                    try:
+                        print("Cloning yay AUR helper...")
+                        # Use streaming subprocess for git clone to show progress
+                        # Git clone can take time depending on network speed
+                        result = subprocess.run(
+                            [
+                                "git",
+                                "clone",
+                                "https://aur.archlinux.org/yay-bin.git",
+                                yay_dir,
+                            ],
+                            check=True,
+                            stderr=subprocess.PIPE,
+                            text=True,
+                            timeout=120,  # 2 minutes should be enough for small repo
+                        )
+                        logger.log_subprocess_result(
+                            "Clone yay AUR helper",
+                            [
+                                "git",
+                                "clone",
+                                "https://aur.archlinux.org/yay-bin.git",
+                                yay_dir,
+                            ],
+                            result,
+                        )
+
+                        print("Building yay (this will prompt for sudo password)...")
+                        # Use streaming subprocess for makepkg to show build progress
+                        # Compilation can take 5-10 minutes and users need to see progress
+                        result = subprocess.run(
+                            ["makepkg", "-si", "--needed", "--noconfirm"],
+                            check=True,
+                            stderr=subprocess.PIPE,
+                            text=True,
+                            timeout=600,  # 10 minutes for compilation
+                            cwd=yay_dir,
+                        )
+                        logger.log_subprocess_result(
+                            "Build yay AUR helper",
+                            ["makepkg", "-si", "--needed", "--noconfirm"],
+                            result,
+                        )
+                        print("✅ Yay AUR helper installed")
+
+                    except Exception:
+                        print(
+                            "💡 Try: Check internet connection and build dependencies"
+                        )
+                        raise
+                else:
+                    print("✅ Yay source already cloned")
+
+            # Check and install main packages
+            all_packages = self.pacman_packages + self.environment_specific[
+                "pacman_packages"
+            ].get(self.environment, [])
+            print(f"Checking {len(all_packages)} pacman packages...")
+
+            installed, missing = self.check_packages_installed(all_packages, logger)
+
+            if installed:
+                print(f"✅ Already installed: {len(installed)} packages")
+
+            if missing:
+                print(f"Installing {len(missing)} missing pacman packages...")
+                try:
+                    pacman("-S", "--needed", "--noconfirm", *missing)
+                    print("✅ All missing pacman packages installed successfully")
+                    self.restart_required = True
+                except subprocess.CalledProcessError as e:
+                    print("❌ ERROR: Some pacman packages failed to install")
+                    print("💡 Try: Check package names and update system")
+                    raise e
+            else:
+                print("✅ All pacman packages already installed")
+
+            # Check and install AUR packages
+            aur_packages = self.aur_packages + self.environment_specific[
+                "aur_packages"
+            ].get(self.environment, [])
+            if aur_packages and yay_installed:
+                print(f"Checking {len(aur_packages)} AUR packages...")
+                installed_aur, missing_aur = self.check_packages_installed(
+                    aur_packages, logger
+                )
+
+                if installed_aur:
+                    print(f"✅ Already installed: {len(installed_aur)} AUR packages")
+
+                if missing_aur:
+                    print(f"Installing {len(missing_aur)} missing AUR packages...")
+                    try:
+                        subprocess.run(
+                            ["yay", "-S", "--needed", "--noconfirm"] + missing_aur,
+                            check=True,
+                            timeout=1800,
+                            capture_output=True,
+                            text=True,
+                        )
+                        print("✅ All missing AUR packages installed successfully")
+                    except subprocess.TimeoutExpired:
+                        print("❌ ERROR: AUR package installation timed out")
+                        raise
+                    except subprocess.CalledProcessError as e:
+                        print("❌ ERROR: Some AUR packages failed to install")
+                        if e.stderr:
+                            print(f"💡 Error details: {e.stderr}")
+                        raise
+                else:
+                    print("✅ All AUR packages already installed")
+            elif aur_packages and not yay_installed:
+                print("⚠️  WARNING: AUR packages requested but yay not available")
+
+            # Check and enable systemd services
+            services_to_enable = (
+                self.systemd_services_to_enable
+                + self.environment_specific["systemd_services_to_enable"].get(
+                    self.environment, []
+                )
+            )
+            if services_to_enable:
+                print(f"Checking {len(services_to_enable)} systemd services...")
+
+            for service in services_to_enable:
+                try:
+                    is_enabled, is_active = check_systemd_service_status(service)
+
+                    if is_enabled and is_active:
+                        print(f"✅ Service already enabled and active: {service}")
+                        continue
+                    elif is_enabled and not is_active:
+                        print(f"🔄 Starting already enabled service: {service}")
+                        subprocess.run(
+                            ["systemctl", "start", service],
+                            check=True,
+                            capture_output=True,
+                            text=True,
+                        )
+                        print(f"✅ Started service: {service}")
+                    else:
+                        print(f"🔄 Enabling and starting service: {service}")
+                        subprocess.run(
+                            ["systemctl", "enable", "--now", service],
+                            check=True,
+                            capture_output=True,
+                            text=True,
+                        )
+                        print(f"✅ Enabled and started service: {service}")
+
+                except subprocess.CalledProcessError as e:
+                    # In containers, systemd services often fail - this is expected
+                    if (
+                        "chroot" in e.stderr.lower()
+                        or "failed to connect to bus" in e.stderr.lower()
+                        or "not available" in e.stderr.lower()
+                    ):
+                        print(
+                            f"⚠️  WARNING: Cannot enable {service} in container environment"
+                        )
+                    else:
+                        print(
+                            f"❌ ERROR: Failed to enable service {service}: {e.stderr}"
+                        )
+                        # Don't raise here - continue with other services
+
+        except KeyboardInterrupt:
+            print("\n❌ Installation interrupted by user")
+            raise
+        except Exception as e:
+            print(f"❌ FATAL ERROR during package installation: {e}")
+            print("💡 Try: Check logs above for specific error details")
+            raise
+
+        # Call parent class
+        super().install_dependencies(logger)
+
+
+class Debian(Linux):
+    def check_packages_installed(self, packages, logger: LoggingHelpers):
+        """Check which packages are already installed via apt"""
+        if not packages:
+            return [], []
+
+        try:
+            installed = []
+            missing = []
+
+            for package in packages:
+                result = subprocess.run(
+                    ["dpkg", "-l", package], capture_output=True, text=True
+                )
+                # dpkg -l returns 0 and shows 'ii' status for installed packages
+                if result.returncode == 0 and f"ii  {package}" in result.stdout:
+                    installed.append(package)
+                else:
+                    missing.append(package)
+
+            return installed, missing
+        except Exception:
+            # If dpkg check fails, assume all packages need installation
+            return [], packages
+
+    def _is_running_in_container(self):
+        """
+        Detect if we're running inside a container (Docker, Podman, etc.)
+
+        This is used to determine if it's safe to modify system settings like timezone.
+        Containers often need timezone pre-configuration to prevent interactive prompts
+        during package installation, while real systems should preserve user settings.
+
+        Detection methods:
+        1. Container-specific files: /.dockerenv (Docker), /run/.containerenv (Podman)
+        2. Process tree analysis: Check /proc/1/cgroup for container runtime signatures
+        3. Virtualization indicators: /proc/vz (OpenVZ/Virtuozzo)
+
+        Returns:
+            bool: True if running in a container/virtualized environment, False otherwise
+
+        Safety note: Defaults to False if detection fails (safer for real systems)
+        """
+        try:
+            # Check for container-specific files/indicators
+            # These files are created by container runtimes and are reliable indicators
+            container_indicators = [
+                "/.dockerenv",  # Docker creates this file in all containers
+                "/run/.containerenv",  # Podman creates this file in all containers
+            ]
+
+            for indicator in container_indicators:
+                if exists(indicator):
+                    return True
+
+            # Check /proc/1/cgroup for container runtime signatures
+            # Container runtimes modify the cgroup hierarchy for process 1 (init)
+            if exists("/proc/1/cgroup"):
+                with open("/proc/1/cgroup", "r") as f:
+                    content = f.read()
+                    # Look for container runtime signatures in the cgroup path
+                    if (
+                        "docker" in content
+                        or "containerd" in content
+                        or "podman" in content
+                    ):
+                        return True
+
+            # Check if running in virtualized environment that might need timezone setup
+            # Some virtualization systems also benefit from timezone pre-configuration
+            if exists("/proc/vz"):  # OpenVZ/Virtuozzo container system
+                return True
+
+            return False
+        except Exception:
+            # If we can't determine container status (permissions, missing files, etc.),
+            # assume we're NOT in a container. This is safer for real user systems
+            # where we don't want to accidentally modify timezone settings.
+            return False
+
+    apt_packages = [
+        "ack",  # text search tool
+        "apt-file",  # search files in packages
+        "build-essential",  # compilation tools and libraries
+        "byobu",  # terminal multiplexer frontend
+        "curl",  # command line URL tool
+        "direnv",  # environment variable manager
+        "fish",  # friendly interactive shell
+        "jq",  # JSON command line processor
+        "libbz2-dev",  # bzip2 development library
+        "libffi-dev",  # foreign function interface library
+        "libfuse2",  # filesystem in userspace library
+        "liblzma-dev",  # XZ compression library
+        "libncursesw5-dev",  # terminal control library
+        "libreadline-dev",  # GNU readline library
+        "libsqlite3-dev",  # SQLite development library
+        "libssl-dev",  # SSL development library
+        "libxml2-dev",  # XML development library
+        "libxmlsec1-dev",  # XML security library
+        "neovim",  # modern Vim text editor
+        "nmap",  # network discovery and scanning
+        "npm",  # Node.js package manager
+        "silversearcher-ag",  # fast text search tool
+        "tig",  # text-mode Git interface
+        "tk-dev",  # Tk GUI toolkit
+        "xz-utils",  # XZ compression utilities
+        "zlib1g-dev",  # compression library
+    ]
+
+    def install_dependencies(self, logger: LoggingHelpers):
+        """Install packages with retry logic and comprehensive error handling"""
+
+        if self.no_remote_mode:
+            print("No-remote mode: Skipping package installation and system updates")
+            return
+
+        # Pre-configure timezone to prevent tzdata interactive prompts
+        #
+        # Problem: The tzdata package (timezone data) can prompt users to select their
+        # geographic region and timezone during installation, even with --assume-yes.
+        # This happens because tzdata uses debconf for configuration, which bypasses
+        # the APT --assume-yes flag.
+        #
+        # Solution: Pre-configure the timezone before package installation so tzdata
+        # finds the timezone already set and skips the interactive configuration.
+        #
+        # Why UTC: It's the safest default for containers and automated environments.
+        # Real systems preserve their existing timezone settings.
+        #
+        # Safety: Only runs in no-remote mode (--no-remote flag) or detected containers,
+        # never on real user systems where timezone might be intentionally set.
+        if self.no_remote_mode or self._is_running_in_container():
+            try:
+                print(
+                    "Pre-configuring timezone to UTC to prevent interactive prompts..."
+                )
+
+                # Step 1: Create symlink from /etc/localtime to UTC timezone data
+                # This is the primary way Linux systems determine the current timezone
+                self.run_command_with_error_handling(
+                    ["sudo", "ln", "-fs", "/usr/share/zoneinfo/UTC", "/etc/localtime"],
+                    logger,
+                    "Set timezone symlink to UTC",
+                    timeout=30,
+                )
+
+                # Step 2: Set the timezone name in /etc/timezone for consistency
+                # Some tools and packages read this file to determine the timezone name
+                self.run_command_with_error_handling(
+                    ["sudo", "sh", "-c", "echo 'UTC' > /etc/timezone"],
+                    logger,
+                    "Set timezone name to UTC",
+                    timeout=30,
+                )
+
+                print("✅ Timezone pre-configured to UTC")
+            except Exception as e:
+                print(f"⚠️  WARNING: Could not pre-configure timezone: {e}")
+                print(
+                    "💡 This may cause interactive prompts during package installation"
+                )
+        else:
+            print("✅ Skipping timezone pre-configuration (running on real system)")
+
+        def apt_get(*args, **kwargs):
+            """
+            Execute APT commands with real-time output, error handling, and retry logic.
+
+            Key improvements implemented here:
+            1. Real-time output streaming (removed capture_output=True)
+            2. Non-interactive environment setup (DEBIAN_FRONTEND=noninteractive)
+            3. Reduced timeout for faster failure detection
+            4. Comprehensive error handling with retries
+
+            Note: DEBIAN_FRONTEND=noninteractive may not work with sudo due to
+            environment variable filtering, but we set it anyway as a fallback.
+            The primary solution is timezone pre-configuration above.
+            """
+            max_retries = 3
+            for attempt in range(max_retries):
+                try:
+                    # Set up non-interactive environment to prevent prompts
+                    #
+                    # Problem: sudo often drops environment variables for security.
+                    # Even with env parameter, DEBIAN_FRONTEND may not reach apt-get.
+                    # This is why we pre-configure timezone as the primary solution.
+                    env = os.environ.copy()
+                    env["DEBIAN_FRONTEND"] = "noninteractive"
+
+                    # Real-time output streaming configuration
+                    #
+                    # Previous problem: capture_output=True hid all APT progress from users.
+                    # Users only saw "Installing X packages..." with no visible progress.
+                    #
+                    # Solution: Remove capture_output=True to show real-time package installation.
+                    # Still capture stderr for error handling while stdout flows to terminal.
+                    #
+                    # Timeout reduced from 1800s (30min) to 600s (10min) for faster failure detection
+                    # while still allowing time for large package downloads.
+                    result = subprocess.run(
+                        ["sudo", "apt-get"] + list(args),
+                        check=True,
+                        stderr=subprocess.PIPE,  # Capture stderr for error analysis
+                        text=True,
+                        timeout=600,  # 10 minute timeout (was 30 min - too long for CI)
+                        env=env,  # Pass environment with DEBIAN_FRONTEND
+                        **kwargs,
+                    )
+                    # Log successful command for debugging
+                    logger.log_subprocess_result(
+                        "APT command", ["sudo", "apt-get"] + list(args), result
+                    )
+                    return result
+                except subprocess.TimeoutExpired:
+                    print(
+                        f"❌ APT operation timed out (attempt {attempt + 1}/{max_retries})"
+                    )
+                    if attempt == max_retries - 1:
+                        print(
+                            "💡 Try: Check internet connection or use different mirror"
+                        )
+                        raise
+                    print("🔄 Retrying in 10 seconds...")
+                    time.sleep(10)
+                except subprocess.CalledProcessError as e:
+                    if "unable to lock" in e.stderr.lower():
+                        print("❌ ERROR: APT database is locked")
+                        print("💡 Try: Wait for other package operations to complete")
+                    elif "no space left" in e.stderr.lower():
+                        print("❌ ERROR: No space left on device")
+                        print("💡 Try: Free up disk space and try again")
+                    elif "permission denied" in e.stderr.lower():
+                        print(
+                            "❌ ERROR: Permission denied - sudo may not be configured"
+                        )
+                        print("💡 Try: Configure sudo or run as appropriate user")
+                    elif "failed to fetch" in e.stderr.lower():
+                        print("❌ ERROR: Failed to fetch packages")
+                        print(
+                            "💡 Try: Check internet connection and repository availability"
+                        )
+                    else:
+                        print(f"❌ ERROR: APT operation failed: {e.stderr}")
+                    raise
+
+        try:
+            # Update package databases
+            print("Updating package databases...")
+            apt_get("update")
+            print("✅ Package databases updated")
+
+            # Upgrade existing packages
+            print("Upgrading existing packages...")
+            try:
+                apt_get("upgrade", "--assume-yes")
+                print("✅ System packages upgraded")
+            except subprocess.CalledProcessError as _:
+                print("⚠️  WARNING: Some packages failed to upgrade")
+                print("💡 This is often non-critical, continuing with installation...")
+
+            # Check and install main packages
+            print(f"Checking {len(self.apt_packages)} APT packages...")
+            installed, missing = self.check_packages_installed(
+                self.apt_packages, logger
+            )
+
+            if installed:
+                print(f"✅ Already installed: {len(installed)} packages")
+
+            if missing:
+                print(f"Installing {len(missing)} missing APT packages...")
+                try:
+                    apt_get("install", "--assume-yes", *missing)
+                    print("✅ All missing APT packages installed successfully")
+                except subprocess.CalledProcessError as _:
+                    print("❌ ERROR: Some APT packages failed to install")
+                    print(
+                        "💡 Try: Check package names and fix any dependency conflicts"
+                    )
+                    raise
+            else:
+                print("✅ All APT packages already installed")
+
+            # Update apt-file database
+            print("Updating apt-file database...")
+            try:
+                subprocess.run(
+                    ["sudo", "apt-file", "update"],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=600,
+                )
+                print("✅ Apt-file database updated")
+            except subprocess.CalledProcessError as _:
+                print("⚠️  WARNING: apt-file update failed")
+                print("💡 This is non-critical, continuing...")
+            except subprocess.TimeoutExpired:
+                print("⚠️  WARNING: apt-file update timed out")
+                print("💡 This is non-critical, continuing...")
+
+            # Download and install latest Neovim AppImage
+            nvim_appimage = expand("./nvim.appimage")
+            if not exists(nvim_appimage):
+                print("Downloading latest Neovim AppImage...")
+                max_retries = 3
+                for attempt in range(max_retries):
+                    try:
+                        # Download with timeout
+                        request = urllib.request.Request(
+                            "https://github.com/neovim/neovim/releases/latest/download/nvim.appimage",
+                            headers={"User-Agent": "dotfiles-installer/1.0"},
+                        )
+
+                        with urllib.request.urlopen(request, timeout=300) as response:
+                            with open(nvim_appimage, "wb") as f:
+                                # Download in chunks to handle large files
+                                while True:
+                                    chunk = response.read(8192)
+                                    if not chunk:
+                                        break
+                                    f.write(chunk)
+
+                        print("✅ Neovim AppImage downloaded successfully")
+                        break
+
+                    except urllib.error.URLError as e:
+                        print(
+                            f"❌ ERROR: Failed to download Neovim (attempt {attempt + 1}/{max_retries}): {e}"
+                        )
+                        if attempt == max_retries - 1:
+                            print(
+                                "💡 Try: Check internet connection or download manually"
+                            )
+                            raise
+                        print("🔄 Retrying in 5 seconds...")
+                        time.sleep(5)
+                    except Exception as e:
+                        print(f"❌ ERROR: Unexpected error downloading Neovim: {e}")
+                        raise
+
+                # Make AppImage executable
+                try:
+                    os.chmod(nvim_appimage, 0o755)
+                    print("✅ Neovim AppImage made executable")
+                except OSError as e:
+                    print(f"❌ ERROR: Failed to make Neovim executable: {e}")
+                    raise
+
+                # Create ~/bin directory
+                bin_dir = expand("~/bin")
+                try:
+                    ensure_path(bin_dir)
+                    print("✅ ~/bin directory created")
+                except OSError as e:
+                    print(f"❌ ERROR: Cannot create ~/bin directory: {e}")
+                    print("💡 Try: Check home directory permissions")
+                    raise
+
+                # Create symlink to nvim
+                nvim_symlink = expand("~/bin/nvim")
+                if not exists(nvim_symlink):
+                    try:
+                        os.symlink(nvim_appimage, nvim_symlink)
+                        print("✅ Neovim symlink created in ~/bin/nvim")
+                    except OSError as e:
+                        print(f"❌ ERROR: Failed to create Neovim symlink: {e}")
+                        print("💡 Try: Check ~/bin directory permissions")
+                        raise
+                else:
+                    print("✅ Neovim symlink already exists")
+            else:
+                print("✅ Neovim AppImage already exists")
+
+        except KeyboardInterrupt:
+            print("\n❌ Installation interrupted by user")
+            raise
+        except Exception as e:
+            print(f"❌ FATAL ERROR during package installation: {e}")
+            print("💡 Try: Check logs above for specific error details")
+            raise
+
+        # Call parent class
+        super().install_dependencies(logger)
+
+
+def detect_operating_system(environment="minimal", no_remote_mode=False):
+    """Detect and return the appropriate operating system class"""
+    with open("/etc/os-release") as release_file:
+        content = release_file.read()
+        if 'NAME="Arch Linux"' in content:
+            return Arch(environment=environment, no_remote_mode=no_remote_mode)
+        elif 'NAME="CachyOS Linux"' in content:
+            return Arch(environment=environment, no_remote_mode=no_remote_mode)
+        elif 'NAME="Garuda Linux"' in content:
+            return Arch(environment=environment, no_remote_mode=no_remote_mode)
+        elif "ID=debian" in content or "ID_LIKE=debian" in content:
+            return Debian(environment=environment, no_remote_mode=no_remote_mode)
+        else:
+            raise NotImplementedError(f"Unknown operating system, found {content}")
+
+
+def show_help():
+    """Display detailed help information"""
+    help_text = """
+Dotfiles Installation Script
+
+USAGE:
+    uv run init.py [OPTIONS]
+
+OPTIONS:
+    --environment {minimal,work,private}
+                        Environment configuration to install (default: minimal)
+    --no-remote        Skip remote activities (GitHub, SSH keys, Tailscale)
+    --help             Show this help message and exit
+
+ENVIRONMENTS:
+    minimal            Basic development tools and CLI utilities
+    work               Minimal environment + work-specific configurations
+    private            Full desktop environment with window manager and GUI apps
+
+WHAT THIS SCRIPT DOES:
+    1. Detects your operating system (Arch/Garuda or Debian-based)
+    2. Installs required packages via package managers
+    3. Creates symlinks for configuration directories to ~/.config/
+    4. Sets up development tools (NVM, Pyenv)
+    5. Configures shell (fish) and prompt (starship)
+    6. Sets up GitHub authentication and SSH keys
+    7. Configures Tailscale (private environment only)
+
+EXAMPLES:
+    export DOTFILES_ENVIRONMENT=minimal && uv run init.py   # Install minimal environment
+    export DOTFILES_ENVIRONMENT=work && uv run init.py      # Install work environment
+    export DOTFILES_ENVIRONMENT=private && uv run init.py   # Install full desktop environment
+    DOTFILES_ENVIRONMENT=minimal uv run init.py --no-remote # Install without remote activities
+
+ENVIRONMENT VARIABLE:
+    DOTFILES_ENVIRONMENT    Required. Must be set to: minimal, work, or private
+                           This prevents accidentally running the wrong environment configuration
+
+For more information, see the README or CLAUDE.md files.
+"""
+    print(help_text)
+
+
+@click.command()
+@click.option(
+    "--no-remote",
+    is_flag=True,
+    help="Skip remote activities (GitHub, SSH keys, Tailscale)",
+)
+@click.option("--quiet", is_flag=True, help="Suppress non-essential output")
+@click.option("--verbose", is_flag=True, help="Show detailed output")
+def main(no_remote, quiet, verbose):
+    """Install and configure dotfiles for Linux systems
+
+    \\b
+    Environment must be set via DOTFILES_ENVIRONMENT environment variable.
+
+    \\b
+    Examples:
+      export DOTFILES_ENVIRONMENT=minimal && dotfiles-init
+      export DOTFILES_ENVIRONMENT=work && dotfiles-init --no-remote
+      export DOTFILES_ENVIRONMENT=private && dotfiles-init --verbose
+
+    \\b
+    Valid environments: minimal, work, private
+    """
+    # Initialize logging and console output
+    logger = setup_logging("init")
+    logger.info("init_script_started")
+    output = ConsoleOutput(verbose=verbose, quiet=quiet)
+
+    try:
+        # Get environment from environment variable
+        environment = os.environ.get("DOTFILES_ENVIRONMENT")
+        if not environment:
+            output.error("DOTFILES_ENVIRONMENT environment variable is not set")
+            output.info(
+                "You must set the environment variable to one of: minimal, work, private"
+            )
+            output.info("Examples:")
+            output.info("   export DOTFILES_ENVIRONMENT=minimal && dotfiles-init")
+            output.info("   export DOTFILES_ENVIRONMENT=work && dotfiles-init")
+            output.info("   export DOTFILES_ENVIRONMENT=private && dotfiles-init")
+            output.info(
+                "This prevents accidentally running the wrong environment configuration"
+            )
+            return 1
+
+        # Validate environment value
+        valid_environments = ["minimal", "work", "private"]
+        if environment not in valid_environments:
+            output.error(f"Invalid DOTFILES_ENVIRONMENT '{environment}'")
+            output.info(f"Must be one of: {', '.join(valid_environments)}")
+            return 1
+
+        # Set up logging context
+        bind_context(environment=environment, no_remote_mode=no_remote)
+        logger.info(
+            "environment_validated", environment=environment, no_remote_mode=no_remote
+        )
+
+        # Create logging helpers for use throughout the script
+        logger = LoggingHelpers(logger)
+
+        output.status(
+            f"Installing dotfiles for {environment} environment{' (no-remote mode)' if no_remote else ''}",
+            "🚀",
+        )
+
+        try:
+            operating_system = detect_operating_system(
+                environment=environment, no_remote_mode=no_remote
+            )
+        except FileNotFoundError:
+            output.error("Cannot detect operating system (/etc/os-release not found)")
+            output.info("This script only supports Linux distributions")
+            return 1
+        except NotImplementedError as e:
+            output.error(str(e))
+            output.info(
+                "This script currently supports Arch Linux, Garuda Linux, and Debian-based systems"
+            )
+            return 1
+
+        # Execute installation steps with individual error handling
+        # Track if changes require terminal restart
+        operating_system.restart_required = False
+
+        steps = [
+            (
+                "Installing dependencies",
+                lambda: operating_system.install_dependencies(logger),
+            ),
+            ("Linking configurations", lambda: operating_system.link_configs(logger)),
+            (
+                "Validating git credential helper",
+                lambda: operating_system.validate_git_credential_helper(logger),
+            ),
+            ("Setting up shell", lambda: operating_system.setup_shell(logger)),
+            ("Setting up accounts", lambda: operating_system.link_accounts(logger)),
+        ]
+
+        # Use Rich progress bar for the installation steps
+        with output.progress_context() as progress:
+            task = progress.add_task("Installing dotfiles...", total=len(steps))
+
+            for i, (step_name, step_func) in enumerate(steps):
+                try:
+                    logger.log_info("step_started", step=step_name)
+                    progress.update(task, description=f"🔄 {step_name}...")
+                    step_func()
+                    logger.log_info("step_completed", step=step_name)
+                    output.success(f"{step_name} completed successfully")
+                    progress.advance(task)
+                except KeyboardInterrupt:
+                    logger.log_warning("step_interrupted", step=step_name)
+                    output.error(f"{step_name} interrupted by user")
+                    return 130  # Standard exit code for SIGINT
+                except Exception as e:
+                    logger.log_exception(
+                        e,
+                        "step_failed",
+                    )
+                    output.error(f"ERROR in {step_name}: {e}")
+                    if verbose:
+                        output.info("DETAILED ERROR INFORMATION:")
+                        traceback.print_exc()
+                        output.info("Check the error details above and retry")
+                    return 1
+
+        logger.log_info(
+            "installation_completed", restart_required=operating_system.restart_required
+        )
+        output.success("Dotfiles installation completed successfully!", "🎉")
+
+        # Only show restart warning if changes were made
+        if operating_system.restart_required:
+            output.info(
+                "You may need to restart your terminal or run 'source ~/.config/fish/config.fish' for changes to take effect"
+            )
+        return 0
+
+    except Exception as e:
+        output.error(f"UNEXPECTED ERROR: {e}")
+        if verbose:
+            output.info("DETAILED ERROR INFORMATION:")
+            traceback.print_exc()
+        output.info("Please report this issue with the full error message")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/dotfiles/logging_config.py
+++ b/src/dotfiles/logging_config.py
@@ -1,0 +1,105 @@
+"""
+Shared logging configuration for all dotfiles Python tools.
+
+Provides structured JSON logging to rotating files with context support.
+Logs go to files only - use Rich console for user interaction.
+"""
+
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+import structlog
+
+
+def setup_logging(script_name: str) -> structlog.BoundLogger:
+    """
+    Configure structured logging for a dotfiles Python tool.
+
+    Args:
+        script_name: Name of the script (e.g., "init", "swman", "pkgstatus")
+
+    Returns:
+        Configured structlog logger
+    """
+    # Ensure log directory exists
+    log_dir = Path.home() / ".cache" / "dotfiles" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    log_file = log_dir / "dotfiles.log"
+
+    # Clear any existing handlers to avoid duplicates
+    logging.getLogger().handlers.clear()
+
+    # Configure standard library logging with rotating file handler
+    logging.basicConfig(
+        handlers=[
+            RotatingFileHandler(
+                log_file,
+                maxBytes=10 * 1024 * 1024,  # 10MB
+                backupCount=5,
+                encoding="utf-8",
+            )
+        ],
+        format="%(message)s",
+        level=logging.INFO,
+    )
+
+    # Configure structlog
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.CallsiteParameterAdder(
+                parameters=[structlog.processors.CallsiteParameter.FILENAME]
+            ),
+            structlog.processors.JSONRenderer(),
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+
+    # Create logger with script context
+    logger = structlog.get_logger()
+    logger = logger.bind(script=script_name, pid=os.getpid())
+
+    return logger
+
+
+def bind_context(**kwargs) -> None:
+    """
+    Bind key-value pairs to the global logging context.
+
+    Useful for setting operation-wide context like environment, user, etc.
+    """
+    structlog.contextvars.bind_contextvars(**kwargs)
+
+
+def unbind_context(*keys) -> None:
+    """
+    Remove specific keys from the global logging context.
+    """
+    structlog.contextvars.unbind_contextvars(*keys)
+
+
+def clear_context() -> None:
+    """
+    Clear all variables from the global logging context.
+    """
+    structlog.contextvars.clear_contextvars()
+
+
+def log_unused_variables(logger: structlog.BoundLogger, **variables) -> None:
+    """
+    Helper to log variables that might be unused in code but useful for debugging.
+
+    This satisfies linters while preserving potentially useful information.
+
+    Args:
+        logger: The structlog logger instance
+        **variables: Key-value pairs of variables to log as context
+    """
+    logger.debug("unused_variables_context", **variables)

--- a/src/dotfiles/pkgstatus.py
+++ b/src/dotfiles/pkgstatus.py
@@ -1,0 +1,556 @@
+#!/usr/bin/env -S uv run python
+"""
+pkgstatus.py - Package and System Status Checker
+
+Python backend for the Fish shell pkgstatus function.
+Handles all complex logic for package, git, and init status checking.
+"""
+
+import json
+import os
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional
+
+import click
+from .logging_config import setup_logging, bind_context
+from .console_output import LoggingHelpers, ConsoleOutput
+
+
+@dataclass
+class StatusResult:
+    packages: Dict
+    git: Dict
+    init: Dict
+
+
+class StatusChecker:
+    def __init__(self, cache_dir: Optional[str] = None):
+        self.cache_dir = (
+            Path(cache_dir or os.environ.get("XDG_CACHE_HOME", "~/.cache")).expanduser()
+            / "dotfiles"
+            / "status"
+        )
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+        # Cache file paths
+        self.packages_cache = self.cache_dir / "packages.json"
+        self.git_cache = self.cache_dir / "git.json"
+        self.init_cache = self.cache_dir / "init.json"
+
+    def get_config(self, key: str, default):
+        """Get Fish universal variable configuration"""
+        try:
+            result = subprocess.run(
+                ["fish", "-c", f"echo $pkgstatus_{key}"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            value = result.stdout.strip()
+            return value if value else default
+        except Exception:
+            return default
+
+    def is_cache_expired(self, cache_file: Path, max_age_hours: int) -> bool:
+        """Check if cache file is expired"""
+        if not cache_file.exists():
+            return True
+
+        file_age = time.time() - cache_file.stat().st_mtime
+        return file_age > (max_age_hours * 3600)
+
+    def get_packages_status(self, force_refresh: bool = False) -> Dict:
+        """Get package status with caching"""
+        cache_hours = int(self.get_config("cache_hours", "6"))
+
+        if force_refresh or self.is_cache_expired(self.packages_cache, cache_hours):
+            self._refresh_packages_cache()
+
+        return self._load_cache(
+            self.packages_cache,
+            {
+                "packages": {},
+                "total_updates": 0,
+                "last_check": 0,
+                "error": "Cache unavailable",
+            },
+        )
+
+    def get_git_status(self, force_refresh: bool = False) -> Dict:
+        """Get git status with caching"""
+        enabled = self.get_config("git_enabled", "true") == "true"
+        if not enabled:
+            return {"enabled": False}
+
+        if force_refresh or self.is_cache_expired(self.git_cache, 1):  # 1 hour cache
+            self._refresh_git_cache()
+
+        return self._load_cache(
+            self.git_cache, {"enabled": True, "error": "Git status unavailable"}
+        )
+
+    def get_init_status(self, force_refresh: bool = False) -> Dict:
+        """Get init script status with caching"""
+        enabled = self.get_config("init_enabled", "true") == "true"
+        if not enabled:
+            return {"enabled": False}
+
+        if force_refresh or self.is_cache_expired(self.init_cache, 24):  # 24 hour cache
+            self._refresh_init_cache()
+
+        return self._load_cache(
+            self.init_cache, {"enabled": True, "error": "Init status unavailable"}
+        )
+
+    def _load_cache(self, cache_file: Path, default: Dict) -> Dict:
+        """Load JSON from cache file with fallback"""
+        try:
+            with open(cache_file, "r") as f:
+                return json.load(f)
+        except Exception:
+            return default
+
+    def _save_cache(self, cache_file: Path, data: Dict):
+        """Save data to cache file atomically"""
+        temp_file = cache_file.with_suffix(".tmp")
+        try:
+            with open(temp_file, "w") as f:
+                json.dump(data, f)
+            temp_file.replace(cache_file)
+        except Exception:
+            if temp_file.exists():
+                temp_file.unlink()
+
+    def _refresh_packages_cache(self):
+        """Refresh package status cache"""
+        timestamp = int(time.time())
+
+        # Try to find swman
+        swman_cmd = None
+        if Path("./swman.py").is_file():
+            swman_cmd = "./swman.py"
+        elif subprocess.run(["which", "swman.py"], capture_output=True).returncode == 0:
+            swman_cmd = "swman.py"
+
+        if swman_cmd:
+            try:
+                result = subprocess.run(
+                    [swman_cmd, "--check", "--json"],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+
+                if result.returncode == 0:
+                    # Extract JSON from output (skip status messages)
+                    output_lines = result.stdout.strip().split("\n")
+
+                    # Find where JSON starts and ends
+                    json_start_idx = -1
+                    json_end_idx = -1
+
+                    for i, line in enumerate(output_lines):
+                        if line.strip().startswith("{"):
+                            json_start_idx = i
+                        elif line.strip() == "}" and json_start_idx != -1:
+                            json_end_idx = i
+                            break
+
+                    if json_start_idx != -1 and json_end_idx != -1:
+                        json_lines = output_lines[json_start_idx : json_end_idx + 1]
+                        json_text = "\n".join(json_lines)
+                        try:
+                            packages_data = json.loads(json_text)
+                            json_line = packages_data
+                        except json.JSONDecodeError:
+                            json_line = None
+                    else:
+                        json_line = None
+
+                    if json_line:
+                        # Transform swman format to our format
+                        packages = {}
+                        total_updates = 0
+
+                        for manager, (has_updates, count) in json_line.items():
+                            packages[manager] = {
+                                "has_updates": has_updates,
+                                "count": count if isinstance(count, int) else 0,
+                            }
+                            if has_updates and isinstance(count, int) and count > 0:
+                                total_updates += count
+
+                        data = {
+                            "packages": packages,
+                            "total_updates": total_updates,
+                            "last_check": timestamp,
+                            "stale": False,
+                        }
+                    else:
+                        data = {
+                            "packages": {},
+                            "total_updates": 0,
+                            "last_check": timestamp,
+                            "error": "Invalid swman output",
+                        }
+                else:
+                    data = {
+                        "packages": {},
+                        "total_updates": 0,
+                        "last_check": timestamp,
+                        "error": "swman check failed",
+                    }
+            except subprocess.TimeoutExpired:
+                data = {
+                    "packages": {},
+                    "total_updates": 0,
+                    "last_check": timestamp,
+                    "error": "swman check timed out",
+                }
+            except Exception as e:
+                data = {
+                    "packages": {},
+                    "total_updates": 0,
+                    "last_check": timestamp,
+                    "error": f"swman error: {e}",
+                }
+        else:
+            data = {
+                "packages": {},
+                "total_updates": 0,
+                "last_check": timestamp,
+                "error": "swman not available",
+            }
+
+        self._save_cache(self.packages_cache, data)
+
+    def _refresh_git_cache(self):
+        """Refresh git status cache"""
+        timestamp = int(time.time())
+        data = {"enabled": True, "last_check": timestamp}
+
+        try:
+            # Check if we're in a git repository
+            result = subprocess.run(
+                ["git", "rev-parse", "--git-dir"], capture_output=True, timeout=5
+            )
+
+            if result.returncode == 0:
+                data["in_repo"] = True
+
+                # Get current branch
+                branch_result = subprocess.run(
+                    ["git", "branch", "--show-current"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                data["branch"] = branch_result.stdout.strip() or "detached"
+
+                # Count uncommitted changes
+                status_result = subprocess.run(
+                    ["git", "status", "--porcelain"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                data["uncommitted"] = (
+                    len(status_result.stdout.strip().split("\n"))
+                    if status_result.stdout.strip()
+                    else 0
+                )
+
+                # Count commits ahead/behind
+                data["ahead"] = 0
+                data["behind"] = 0
+
+                if data["branch"] != "detached":
+                    try:
+                        upstream_result = subprocess.run(
+                            ["git", "rev-parse", "--abbrev-ref", "@{upstream}"],
+                            capture_output=True,
+                            text=True,
+                            timeout=5,
+                        )
+                        if upstream_result.returncode == 0:
+                            upstream = upstream_result.stdout.strip()
+
+                            counts_result = subprocess.run(
+                                [
+                                    "git",
+                                    "rev-list",
+                                    "--left-right",
+                                    "--count",
+                                    f"{upstream}...HEAD",
+                                ],
+                                capture_output=True,
+                                text=True,
+                                timeout=5,
+                            )
+                            if counts_result.returncode == 0:
+                                counts = counts_result.stdout.strip().split()
+                                if len(counts) == 2:
+                                    data["behind"] = int(counts[0])
+                                    data["ahead"] = int(counts[1])
+                    except Exception:
+                        pass  # No upstream or other git issue
+            else:
+                data["in_repo"] = False
+
+        except Exception as e:
+            data["error"] = f"Git check failed: {e}"
+
+        self._save_cache(self.git_cache, data)
+
+    def _refresh_init_cache(self):
+        """Refresh init script status cache"""
+        timestamp = int(time.time())
+        data = {"enabled": True, "last_check": timestamp}
+
+        # Check if we're in dotfiles directory
+        if Path("./init.py").exists():
+            data["in_dotfiles"] = True
+
+            # Check last run time
+            last_run_file = Path.home() / ".cache" / "dotfiles_last_update"
+            last_run = 0
+
+            if last_run_file.exists():
+                try:
+                    with open(last_run_file, "r") as f:
+                        last_run_str = f.read().strip()
+                    # Parse ISO format timestamp
+                    from datetime import datetime
+
+                    last_run_dt = datetime.fromisoformat(last_run_str)
+                    last_run = int(last_run_dt.timestamp())
+                except Exception:
+                    pass
+
+            data["last_run"] = last_run
+            age_hours = (timestamp - last_run) / 3600
+            data["age_hours"] = age_hours
+
+            # Consider update needed if more than 7 days old
+            data["needs_update"] = age_hours > 168
+        else:
+            data["in_dotfiles"] = False
+
+        self._save_cache(self.init_cache, data)
+
+    def get_status(self, force_refresh: bool = False) -> StatusResult:
+        """Get complete status"""
+        return StatusResult(
+            packages=self.get_packages_status(force_refresh),
+            git=self.get_git_status(force_refresh),
+            init=self.get_init_status(force_refresh),
+        )
+
+    def format_quiet_output(self, status: StatusResult) -> str:
+        """Format output for quiet mode (only show if issues)"""
+        messages = []
+
+        # Check package updates
+        pkg_data = status.packages
+        total_updates = pkg_data.get("total_updates", 0)
+        if total_updates > 0:
+            if pkg_data.get("stale", False):
+                messages.append(
+                    f"⚠️  {total_updates} package updates available (stale cache)"
+                )
+            else:
+                last_check = pkg_data.get("last_check", 0)
+                age = self._format_age(last_check)
+                messages.append(f"⚠️  {total_updates} package updates available ({age})")
+
+        # Check git status
+        git_data = status.git
+        if git_data.get("enabled", False) and git_data.get("in_repo", False):
+            uncommitted = git_data.get("uncommitted", 0)
+            ahead = git_data.get("ahead", 0)
+            if uncommitted > 0 or ahead > 0:
+                git_msg = "🔄 Git:"
+                if uncommitted > 0:
+                    git_msg += f" {uncommitted} uncommitted"
+                if ahead > 0:
+                    git_msg += f" {ahead} unpushed"
+                messages.append(git_msg)
+
+        # Check init status
+        init_data = status.init
+        if init_data.get("enabled", False) and init_data.get("needs_update", False):
+            age_hours = init_data.get("age_hours", 0)
+            messages.append(f"⚙️  Init script not run in {int(age_hours / 24)}d")
+
+        # Add tool name prefix to all messages
+        if messages:
+            prefixed_messages = [f"pkgstatus: {messages[0]}"]
+            prefixed_messages.extend(f"pkgstatus: {msg}" for msg in messages[1:])
+            return "\n".join(prefixed_messages)
+        return ""
+
+    def format_interactive_output(self, status: StatusResult) -> str:
+        """Format output for interactive mode"""
+        lines = ["📦 Package Status:"]
+
+        # Package status
+        pkg_data = status.packages
+        pkg_error = pkg_data.get("error")
+        if pkg_error:
+            lines.append(f"   ❌ {pkg_error}")
+        else:
+            total_updates = pkg_data.get("total_updates", 0)
+            if total_updates > 0:
+                if pkg_data.get("stale", False):
+                    lines.append(
+                        f"   ⚠️  {total_updates} updates available (checking for new updates...)"
+                    )
+                else:
+                    last_check = pkg_data.get("last_check", 0)
+                    age = self._format_age(last_check)
+                    lines.append(
+                        f"   ⚠️  {total_updates} updates available (checked {age})"
+                    )
+
+                # Show breakdown by manager
+                packages = pkg_data.get("packages", {})
+                for manager, info in packages.items():
+                    if info.get("has_updates", False):
+                        count = info.get("count", 0)
+                        if count > 0:
+                            lines.append(f"      • {manager}: {count} updates")
+                        else:
+                            lines.append(f"      • {manager}: updates available")
+            else:
+                lines.append("   ✅ All packages up to date")
+
+        # Git status
+        git_data = status.git
+        if git_data.get("enabled", False):
+            lines.extend(["", "🔄 Git Status:"])
+            git_error = git_data.get("error")
+            if git_error:
+                lines.append(f"   ❌ {git_error}")
+            elif git_data.get("in_repo", False):
+                branch = git_data.get("branch", "unknown")
+                uncommitted = git_data.get("uncommitted", 0)
+                ahead = git_data.get("ahead", 0)
+                behind = git_data.get("behind", 0)
+
+                lines.append(f"   📁 Branch: {branch}")
+                if uncommitted > 0:
+                    lines.append(f"   ⚠️  {uncommitted} uncommitted changes")
+                if ahead > 0:
+                    lines.append(f"   ⬆️  {ahead} commits ahead of origin")
+                if behind > 0:
+                    lines.append(f"   ⬇️  {behind} commits behind origin")
+                if uncommitted == 0 and ahead == 0 and behind == 0:
+                    lines.append("   ✅ Working tree clean and up to date")
+            else:
+                lines.append("   ℹ️  Not in a git repository")
+
+        # Init status
+        init_data = status.init
+        if init_data.get("enabled", False):
+            lines.extend(["", "⚙️  Init Status:"])
+            init_error = init_data.get("error")
+            if init_error:
+                lines.append(f"   ❌ {init_error}")
+            elif init_data.get("in_dotfiles", False):
+                if init_data.get("needs_update", False):
+                    age_hours = init_data.get("age_hours", 0)
+                    lines.append(
+                        f"   ⚠️  Last run {int(age_hours / 24)}d ago - consider running"
+                    )
+                else:
+                    last_run = init_data.get("last_run", 0)
+                    age_desc = self._format_age(last_run)
+                    lines.append(f"   ✅ Recently run ({age_desc})")
+            else:
+                lines.append("   ℹ️  Not in dotfiles directory")
+
+        return "\n".join(lines)
+
+    def _format_age(self, timestamp: int) -> str:
+        """Format timestamp age as human readable"""
+        if timestamp == 0:
+            return "never"
+
+        age = int(time.time()) - timestamp
+
+        if age < 60:
+            return "just now"
+        elif age < 3600:
+            return f"{age // 60}m ago"
+        elif age < 86400:
+            return f"{age // 3600}h ago"
+        else:
+            return f"{age // 86400}d ago"
+
+
+@click.command()
+@click.option("--quiet", is_flag=True, help="Only show if issues exist")
+@click.option("--json", "json_output", is_flag=True, help="JSON output")
+@click.option("--refresh", is_flag=True, help="Force cache refresh")
+@click.option("--cache-dir", help="Override cache directory")
+@click.option("--verbose", is_flag=True, help="Show detailed output")
+def main(quiet, json_output, refresh, cache_dir, verbose):
+    """Package and system status checker
+
+    \b
+    To perform updates:
+      Package updates:  Use 'dotfiles-swman --system' or 'dotfiles-swman --all'
+      Git operations:   Use 'git add', 'git commit', 'git push'
+      Init script:      Run 'dotfiles-init' in dotfiles directory
+
+    For more information, see the README or run 'dotfiles-swman --help'
+    """
+    # Initialize logging and console output
+    logger = setup_logging("pkgstatus")
+    logger = LoggingHelpers(logger)
+    output = ConsoleOutput(verbose=verbose, quiet=quiet)
+    logger.log_info("pkgstatus_started")
+
+    # Set up logging context
+    bind_context(quiet=quiet, json_output=json_output, refresh=refresh)
+    logger.log_info(
+        "pkgstatus_operation_started",
+        quiet=quiet,
+        json_output=json_output,
+        refresh=refresh,
+    )
+
+    checker = StatusChecker(cache_dir)
+    status = checker.get_status(refresh)
+
+    # Log status summary
+    logger.log_info(
+        "status_check_completed",
+        packages_status=status.packages.get("status", "unknown"),
+        packages_count=status.packages.get("available", 0),
+        git_status=status.git.get("status", "unknown"),
+        init_status=status.init.get("status", "unknown"),
+    )
+
+    if json_output:
+        status_output = {
+            "packages": status.packages,
+            "git": status.git,
+            "init": status.init,
+        }
+        output.json(status_output)
+    elif quiet:
+        quiet_output = checker.format_quiet_output(status)
+        if quiet_output:  # Only print if there are issues
+            click.echo(quiet_output)
+    else:
+        # Display interactive output with Rich formatting
+        interactive_output = checker.format_interactive_output(status)
+        click.echo(interactive_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dotfiles/swman.py
+++ b/src/dotfiles/swman.py
@@ -1,0 +1,705 @@
+#!/usr/bin/env -S uv run python
+"""
+swman - Software Manager Orchestrator
+
+A unified interface to manage updates across multiple package managers
+and tools. Designed to work with any system, not just dotfiles.
+
+KEY IMPROVEMENT: Now shows full package manager output instead of hiding it.
+All package update operations (pacman, yay, uv tools, lazy.nvim, fisher)
+display real-time progress so users can see what packages are being updated.
+"""
+
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import click
+from .logging_config import setup_logging, bind_context
+from .console_output import LoggingHelpers, ConsoleOutput
+
+
+def run_with_streaming_output(
+    command: List[str], timeout: int = 600
+) -> subprocess.CompletedProcess:
+    """
+    Execute command with real-time output streaming for package managers.
+
+    This function shows full package manager output to users instead of hiding it,
+    while still capturing stderr for error handling and maintaining return codes.
+
+    Args:
+        command: Command to execute as list of strings
+        timeout: Timeout in seconds (default 600 = 10 minutes)
+
+    Returns:
+        CompletedProcess with returncode and stderr (stdout flows to terminal)
+
+    Note: This follows the same pattern used in init.py for APT/pacman streaming.
+    """
+    return subprocess.run(
+        command,
+        check=False,  # Don't raise exception, let caller handle return codes
+        stderr=subprocess.PIPE,  # Capture stderr for error analysis
+        text=True,
+        timeout=timeout,
+    )
+
+
+class ManagerType(Enum):
+    SYSTEM = "system"
+    LANGUAGE = "language"
+    PLUGIN = "plugin"
+    TOOL = "tool"
+
+
+class UpdateStatus(Enum):
+    SUCCESS = "success"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+    NOT_AVAILABLE = "not_available"
+
+
+@dataclass
+class ManagerResult:
+    name: str
+    status: UpdateStatus
+    message: str
+    duration: float
+    updates_available: int = 0
+    updates_applied: int = 0
+
+
+class PackageManager:
+    def __init__(self, name: str, manager_type: ManagerType):
+        self.name = name
+        self.type = manager_type
+
+    def is_available(self) -> bool:
+        """Check if this package manager is available on the system."""
+        raise NotImplementedError
+
+    def check_updates(self) -> Tuple[bool, int]:
+        """Check for available updates. Returns (has_updates, count)."""
+        raise NotImplementedError
+
+    def update(self, dry_run: bool = False) -> ManagerResult:
+        """Perform the update operation."""
+        raise NotImplementedError
+
+
+class PacmanManager(PackageManager):
+    def __init__(self):
+        super().__init__("pacman", ManagerType.SYSTEM)
+
+    def is_available(self) -> bool:
+        return self._command_exists("pacman")
+
+    def check_updates(self) -> Tuple[bool, int]:
+        try:
+            result = subprocess.run(
+                ["checkupdates"], capture_output=True, text=True, timeout=30
+            )
+            if result.returncode == 0:
+                count = (
+                    len(result.stdout.strip().split("\n"))
+                    if result.stdout.strip()
+                    else 0
+                )
+                return count > 0, count
+            return False, 0
+        except (subprocess.SubprocessError, FileNotFoundError):
+            return False, 0
+
+    def update(self, dry_run: bool = False) -> ManagerResult:
+        start_time = time.time()
+
+        if dry_run:
+            has_updates, count = self.check_updates()
+            return ManagerResult(
+                name=self.name,
+                status=UpdateStatus.SUCCESS,
+                message=f"Would update {count} packages",
+                duration=time.time() - start_time,
+                updates_available=count,
+            )
+
+        try:
+            # Use streaming output to show real-time pacman progress
+            result = run_with_streaming_output(
+                ["sudo", "pacman", "-Syu", "--noconfirm"], timeout=600
+            )
+
+            if result.returncode == 0:
+                # Parse output to count actual updates
+                return ManagerResult(
+                    name=self.name,
+                    status=UpdateStatus.SUCCESS,
+                    message="System packages updated successfully",
+                    duration=time.time() - start_time,
+                )
+            else:
+                return ManagerResult(
+                    name=self.name,
+                    status=UpdateStatus.FAILED,
+                    message=f"Update failed: {result.stderr}",
+                    duration=time.time() - start_time,
+                )
+        except subprocess.TimeoutExpired:
+            return ManagerResult(
+                name=self.name,
+                status=UpdateStatus.FAILED,
+                message="Update timed out",
+                duration=time.time() - start_time,
+            )
+        except Exception as e:
+            return ManagerResult(
+                name=self.name,
+                status=UpdateStatus.FAILED,
+                message=f"Unexpected error: {e}",
+                duration=time.time() - start_time,
+            )
+
+    @staticmethod
+    def _command_exists(command: str) -> bool:
+        try:
+            subprocess.run(["which", command], capture_output=True, check=True)
+            return True
+        except subprocess.CalledProcessError:
+            return False
+
+
+class YayManager(PackageManager):
+    def __init__(self):
+        super().__init__("yay", ManagerType.SYSTEM)
+
+    def is_available(self) -> bool:
+        return self._command_exists("yay")
+
+    def check_updates(self) -> Tuple[bool, int]:
+        try:
+            result = subprocess.run(
+                ["yay", "-Qu"], capture_output=True, text=True, timeout=60
+            )
+            if result.returncode == 0:
+                count = (
+                    len(result.stdout.strip().split("\n"))
+                    if result.stdout.strip()
+                    else 0
+                )
+                return count > 0, count
+            return False, 0
+        except (subprocess.SubprocessError, FileNotFoundError):
+            return False, 0
+
+    def update(self, dry_run: bool = False) -> ManagerResult:
+        start_time = time.time()
+
+        if dry_run:
+            has_updates, count = self.check_updates()
+            return ManagerResult(
+                name=self.name,
+                status=UpdateStatus.SUCCESS,
+                message=f"Would update {count} AUR packages",
+                duration=time.time() - start_time,
+                updates_available=count,
+            )
+
+        try:
+            # Use streaming output to show real-time yay/AUR progress
+            result = run_with_streaming_output(
+                ["yay", "-Syu", "--noconfirm"],
+                timeout=1800,  # 30 minutes for AUR builds
+            )
+
+            if result.returncode == 0:
+                return ManagerResult(
+                    name=self.name,
+                    status=UpdateStatus.SUCCESS,
+                    message="AUR packages updated successfully",
+                    duration=time.time() - start_time,
+                )
+            else:
+                return ManagerResult(
+                    name=self.name,
+                    status=UpdateStatus.FAILED,
+                    message=f"AUR update failed: {result.stderr}",
+                    duration=time.time() - start_time,
+                )
+        except subprocess.TimeoutExpired:
+            return ManagerResult(
+                name=self.name,
+                status=UpdateStatus.FAILED,
+                message="AUR update timed out",
+                duration=time.time() - start_time,
+            )
+        except Exception as e:
+            return ManagerResult(
+                name=self.name,
+                status=UpdateStatus.FAILED,
+                message=f"Unexpected error: {e}",
+                duration=time.time() - start_time,
+            )
+
+    @staticmethod
+    def _command_exists(command: str) -> bool:
+        try:
+            subprocess.run(["which", command], capture_output=True, check=True)
+            return True
+        except subprocess.CalledProcessError:
+            return False
+
+
+class UvToolsManager(PackageManager):
+    def __init__(self):
+        super().__init__("uv-tools", ManagerType.TOOL)
+
+    def is_available(self) -> bool:
+        return self._command_exists("uv")
+
+    def check_updates(self) -> Tuple[bool, int]:
+        """Check for UV tool updates without installing anything.
+
+        Returns (False, 0) conservatively since UV doesn't provide
+        a reliable way to check for tool updates without attempting updates.
+        This prevents unwanted installations during check operations.
+        """
+        logger = LoggingHelpers(setup_logging("swman"))
+        logger.log_info("uv_check_started")
+
+        try:
+            # Get list of installed UV tools to verify UV is working
+            result = subprocess.run(
+                ["uv", "tool", "list"],
+                capture_output=True,
+                text=True,
+                timeout=30
+            )
+            logger.log_subprocess_result("uv tool list", ["uv", "tool", "list"], result)
+
+            if result.returncode == 0:
+                # UV is working, but conservatively report no updates
+                # since UV doesn't have a reliable --check-only mode yet
+                logger.log_info("uv_check_completed", status="conservative_no_updates", reason="no_reliable_check_mode")
+                return False, 0
+            else:
+                # UV command failed, report no updates
+                logger.log_info("uv_check_completed", status="command_failed", returncode=result.returncode)
+                return False, 0
+
+        except (subprocess.SubprocessError, FileNotFoundError, subprocess.TimeoutExpired) as e:
+            # UV not available or timeout, report no updates
+            logger.log_exception(e, "uv check failed")
+            return False, 0
+
+    def update(self, dry_run: bool = False) -> ManagerResult:
+        start_time = time.time()
+
+        if dry_run:
+            return ManagerResult(
+                name=self.name,
+                status=UpdateStatus.SUCCESS,
+                message="Would upgrade all uv tools",
+                duration=time.time() - start_time,
+            )
+
+        try:
+            # Use streaming output to show real-time UV tool upgrade progress
+            result = run_with_streaming_output(
+                ["uv", "tool", "upgrade", "--all"], timeout=300
+            )
+
+            if result.returncode == 0:
+                return ManagerResult(
+                    name=self.name,
+                    status=UpdateStatus.SUCCESS,
+                    message="UV tools updated successfully",
+                    duration=time.time() - start_time,
+                )
+            else:
+                return ManagerResult(
+                    name=self.name,
+                    status=UpdateStatus.FAILED,
+                    message=f"UV tools update failed: {result.stderr}",
+                    duration=time.time() - start_time,
+                )
+        except Exception as e:
+            return ManagerResult(
+                name=self.name,
+                status=UpdateStatus.FAILED,
+                message=f"Unexpected error: {e}",
+                duration=time.time() - start_time,
+            )
+
+    @staticmethod
+    def _command_exists(command: str) -> bool:
+        try:
+            subprocess.run(["which", command], capture_output=True, check=True)
+            return True
+        except subprocess.CalledProcessError:
+            return False
+
+
+class LazyNvimManager(PackageManager):
+    def __init__(self):
+        super().__init__("lazy.nvim", ManagerType.PLUGIN)
+
+    def is_available(self) -> bool:
+        lazy_path = Path.home() / ".local/share/nvim/lazy/lazy.nvim"
+        return lazy_path.exists() and self._command_exists("nvim")
+
+    def check_updates(self) -> Tuple[bool, int]:
+        """Check for Neovim plugin updates without triggering installations.
+
+        Returns (False, 0) conservatively to prevent unwanted plugin
+        installations during check operations. Lazy.nvim can handle
+        its own update checking when explicitly requested.
+        """
+        # Don't assume updates are available during check operations
+        # Lazy.nvim will handle its own update notifications when appropriate
+        return False, 0
+
+    def update(self, dry_run: bool = False) -> ManagerResult:
+        start_time = time.time()
+
+        if dry_run:
+            return ManagerResult(
+                name=self.name,
+                status=UpdateStatus.SUCCESS,
+                message="Would update Neovim plugins",
+                duration=time.time() - start_time,
+            )
+
+        try:
+            # Use streaming output to show real-time Neovim plugin updates
+            _ = run_with_streaming_output(
+                ["nvim", "--headless", "+Lazy! sync", "+qa"], timeout=300
+            )
+
+            return ManagerResult(
+                name=self.name,
+                status=UpdateStatus.SUCCESS,
+                message="Neovim plugins updated",
+                duration=time.time() - start_time,
+            )
+        except Exception as e:
+            return ManagerResult(
+                name=self.name,
+                status=UpdateStatus.FAILED,
+                message=f"Neovim plugin update failed: {e}",
+                duration=time.time() - start_time,
+            )
+
+    @staticmethod
+    def _command_exists(command: str) -> bool:
+        try:
+            subprocess.run(["which", command], capture_output=True, check=True)
+            return True
+        except subprocess.CalledProcessError:
+            return False
+
+
+class FisherManager(PackageManager):
+    def __init__(self):
+        super().__init__("fisher", ManagerType.PLUGIN)
+
+    def is_available(self) -> bool:
+        return (
+            self._command_exists("fish")
+            and Path.home().joinpath(".config/fish/functions/fisher.fish").exists()
+        )
+
+    def check_updates(self) -> Tuple[bool, int]:
+        """Check for Fish plugin updates without triggering installations.
+
+        Returns (False, 0) conservatively to prevent unwanted plugin
+        installations during check operations. Fisher can handle
+        its own update checking when explicitly requested.
+        """
+        # Don't assume updates are available during check operations
+        # Fisher will handle its own update process when explicitly called
+        return False, 0
+
+    def update(self, dry_run: bool = False) -> ManagerResult:
+        start_time = time.time()
+
+        if dry_run:
+            return ManagerResult(
+                name=self.name,
+                status=UpdateStatus.SUCCESS,
+                message="Would update Fish plugins",
+                duration=time.time() - start_time,
+            )
+
+        try:
+            # Use streaming output to show real-time Fish plugin updates
+            _ = run_with_streaming_output(["fish", "-c", "fisher update"], timeout=120)
+
+            return ManagerResult(
+                name=self.name,
+                status=UpdateStatus.SUCCESS,
+                message="Fish plugins updated",
+                duration=time.time() - start_time,
+            )
+        except Exception as e:
+            return ManagerResult(
+                name=self.name,
+                status=UpdateStatus.FAILED,
+                message=f"Fish plugin update failed: {e}",
+                duration=time.time() - start_time,
+            )
+
+    @staticmethod
+    def _command_exists(command: str) -> bool:
+        try:
+            subprocess.run(["which", command], capture_output=True, check=True)
+            return True
+        except subprocess.CalledProcessError:
+            return False
+
+
+class SoftwareManagerOrchestrator:
+    def __init__(self):
+        self.managers: List[PackageManager] = [
+            PacmanManager(),
+            YayManager(),
+            UvToolsManager(),
+            LazyNvimManager(),
+            FisherManager(),
+        ]
+
+    def get_available_managers(self) -> List[PackageManager]:
+        return [mgr for mgr in self.managers if mgr.is_available()]
+
+    def check_all(self) -> Dict[str, Tuple[bool, int]]:
+        """Check all managers for updates without installing anything."""
+        logger = LoggingHelpers(setup_logging("swman"))
+        logger.log_info("check_all_started", available_managers=len(self.get_available_managers()))
+
+        results = {}
+        for manager in self.get_available_managers():
+            try:
+                logger.log_info("checking_manager", manager=manager.name)
+                has_updates, count = manager.check_updates()
+                results[manager.name] = (has_updates, count)
+                logger.log_info(
+                    "manager_check_completed",
+                    manager=manager.name,
+                    has_updates=has_updates,
+                    count=count
+                )
+            except Exception as e:
+                # Log error instead of print - this gets logged to structured logs
+                logger.log_error(
+                    f"Error checking {manager.name}", error=str(e), manager=manager.name
+                )
+                results[manager.name] = (False, 0)
+
+        total_updates = sum(count for has_updates, count in results.values() if has_updates)
+        logger.log_info("check_all_completed", total_managers_checked=len(results), total_updates=total_updates)
+        return results
+
+    def update_by_type(
+        self, manager_type: ManagerType, dry_run: bool = False
+    ) -> List[ManagerResult]:
+        """Update all managers of a specific type."""
+        results = []
+        for manager in self.get_available_managers():
+            if manager.type == manager_type:
+                try:
+                    result = manager.update(dry_run)
+                    results.append(result)
+                except Exception as e:
+                    results.append(
+                        ManagerResult(
+                            name=manager.name,
+                            status=UpdateStatus.FAILED,
+                            message=f"Unexpected error: {e}",
+                            duration=0.0,
+                        )
+                    )
+        return results
+
+    def update_all(self, dry_run: bool = False) -> List[ManagerResult]:
+        """Update all available managers."""
+        results = []
+        for manager in self.get_available_managers():
+            try:
+                result = manager.update(dry_run)
+                results.append(result)
+            except Exception as e:
+                results.append(
+                    ManagerResult(
+                        name=manager.name,
+                        status=UpdateStatus.FAILED,
+                        message=f"Unexpected error: {e}",
+                        duration=0.0,
+                    )
+                )
+        return results
+
+
+def print_status_table(
+    check_results: Dict[str, Tuple[bool, int]], output: ConsoleOutput
+):
+    """Print a nice status table using Rich."""
+    rows = []
+    for name, (has_updates, count) in check_results.items():
+        status = "Updates Available" if has_updates else "Up to Date"
+        updates_str = str(count) if count > 0 else "-"
+        rows.append([name, status, updates_str])
+
+    output.table("Software Manager Status", ["Manager", "Status", "Updates"], rows)
+
+
+def print_results_summary(results: List[ManagerResult], output: ConsoleOutput):
+    """Print update results summary using Rich."""
+    rows = []
+    for result in results:
+        status_icon = {
+            UpdateStatus.SUCCESS: "✅",
+            UpdateStatus.FAILED: "❌",
+            UpdateStatus.SKIPPED: "⏭️",
+            UpdateStatus.NOT_AVAILABLE: "⚠️",
+        }.get(result.status, "❓")
+
+        duration_str = f"{result.duration:.1f}s" if result.duration > 0 else "-"
+        rows.append([status_icon, result.name, result.message, duration_str])
+
+    output.table(
+        "Update Results", ["Status", "Manager", "Message", "Duration"], rows, emoji="🔄"
+    )
+
+
+@click.command()
+@click.option("--check", is_flag=True, help="Check for updates across all managers")
+@click.option(
+    "--system", is_flag=True, help="Update system packages only (pacman, yay, apt)"
+)
+@click.option("--tools", is_flag=True, help="Update development tools (uv, etc.)")
+@click.option("--plugins", is_flag=True, help="Update plugins (nvim, fish, tmux)")
+@click.option("--all", "update_all", is_flag=True, help="Update everything")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show what would be updated without actually updating",
+)
+@click.option(
+    "--json", "json_output", is_flag=True, help="Output results in JSON format"
+)
+@click.option("--quiet", is_flag=True, help="Suppress non-essential output")
+@click.option("--verbose", is_flag=True, help="Show detailed output")
+def main(
+    check, system, tools, plugins, update_all, dry_run, json_output, quiet, verbose
+):
+    """Software Manager Orchestrator - Unified package manager updates"""
+
+    # Initialize logging and console output
+    logger = setup_logging("swman")
+    logger = LoggingHelpers(logger)
+    output = ConsoleOutput(verbose=verbose, quiet=quiet)
+    logger.log_info("swman_started")
+
+    if not any([check, system, tools, plugins, update_all]):
+        click.echo("Error: Must specify at least one operation")
+        ctx = click.get_current_context()
+        click.echo(ctx.get_help())
+        return 1
+
+    orchestrator = SoftwareManagerOrchestrator()
+
+    if check:
+        logger.log_info("check_operation_started")
+        output.status("Checking for updates...")
+        check_results = orchestrator.check_all()
+        # check_results is Dict[str, Tuple[bool, int]] where tuple is (success, updates_count)
+        total_updates = sum(
+            r[1] for r in check_results.values() if r[0]
+        )  # r[1] is updates_count, r[0] is success
+        logger.log_info(
+            "check_operation_completed",
+            total_managers=len(check_results),
+            managers_with_updates=sum(
+                1 for r in check_results.values() if r[0] and r[1] > 0
+            ),
+            total_updates_available=total_updates,
+        )
+
+        if json_output:
+            output.json(check_results)
+        else:
+            print_status_table(check_results, output)
+        return 0
+
+    results = []
+
+    # Set up operation context
+    operation_types = []
+    if system:
+        operation_types.append("system")
+    if tools:
+        operation_types.append("tools")
+    if plugins:
+        operation_types.append("plugins")
+    if update_all:
+        operation_types.append("all")
+
+    bind_context(operation_types=operation_types, dry_run=dry_run)
+
+    if system:
+        logger.log_info("system_update_started")
+        output.status("Updating system packages...", "🔄")
+        results.extend(orchestrator.update_by_type(ManagerType.SYSTEM, dry_run))
+
+    if tools:
+        logger.log_info("tools_update_started")
+        output.status("Updating development tools...", "🔧")
+        results.extend(orchestrator.update_by_type(ManagerType.TOOL, dry_run))
+
+    if plugins:
+        logger.log_info("plugins_update_started")
+        output.status("Updating plugins...", "🔌")
+        results.extend(orchestrator.update_by_type(ManagerType.PLUGIN, dry_run))
+
+    if update_all:
+        logger.log_info("all_update_started")
+        output.status("Updating everything...", "🚀")
+        results.extend(orchestrator.update_all(dry_run))
+
+    if json_output:
+        output.json(
+            [
+                {
+                    "name": r.name,
+                    "status": r.status.value,
+                    "message": r.message,
+                    "duration": r.duration,
+                    "updates_available": r.updates_available,
+                    "updates_applied": r.updates_applied,
+                }
+                for r in results
+            ]
+        )
+    else:
+        print_results_summary(results, output)
+
+    # Log completion and return appropriate exit code
+    failed_count = sum(1 for r in results if r.status == UpdateStatus.FAILED)
+    success_count = sum(1 for r in results if r.status == UpdateStatus.SUCCESS)
+
+    logger.log_info(
+        "swman_completed",
+        total_operations=len(results),
+        successful=success_count,
+        failed=failed_count,
+    )
+
+    return 1 if failed_count > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "dotfiles"
+version = "0.1.0"
+description = "Personal dotfiles and system management tools"
+requires-python = ">=3.12.3"
+dependencies = [
+    "structlog>=25.4.0",
+    "rich>=13.0.0",
+    "click>=8.0.0",
+]
+
+[project.scripts]
+dotfiles-init = "init:main"
+dotfiles-swman = "swman:main"
+dotfiles-pkgstatus = "pkgstatus:main"
+
+[tool.hatch.build.targets.wheel]
+include = [
+    "init.py",
+    "swman.py",
+    "pkgstatus.py",
+    "logging_config.py"
+]

--- a/src/uv.lock
+++ b/src/uv.lock
@@ -1,0 +1,93 @@
+version = 1
+revision = 3
+requires-python = ">=3.12.3"
+
+[[package]]
+name = "click"
+version = "8.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/61/de6cd827efad202d7057d93e0fed9294b96952e188f7384832791c7b2254/click-8.3.0.tar.gz", hash = "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4", size = 276943, upload-time = "2025-09-18T17:32:23.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/d3/9dcc0f5797f070ec8edf30fbadfb200e71d9db6b84d211e3b2085a7589a0/click-8.3.0-py3-none-any.whl", hash = "sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc", size = 107295, upload-time = "2025-09-18T17:32:22.42Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "dotfiles"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "structlog" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "click", specifier = ">=8.0.0" },
+    { name = "rich", specifier = ">=13.0.0" },
+    { name = "structlog", specifier = ">=25.4.0" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/75/af448d8e52bf1d8fa6a9d089ca6c07ff4453d86c65c145d0a300bb073b9b/rich-14.1.0.tar.gz", hash = "sha256:e497a48b844b0320d45007cdebfeaeed8db2a4f4bcf49f15e455cfc4af11eaa8", size = 224441, upload-time = "2025-07-25T07:32:58.125Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/30/3c4d035596d3cf444529e0b2953ad0466f6049528a879d27534700580395/rich-14.1.0-py3-none-any.whl", hash = "sha256:536f5f1785986d6dbdea3c75205c473f970777b4a0d6c6dd1b696aa05a3fa04f", size = 243368, upload-time = "2025-07-25T07:32:56.73Z" },
+]
+
+[[package]]
+name = "structlog"
+version = "25.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/b9/6e672db4fec07349e7a8a8172c1a6ae235c58679ca29c3f86a61b5e59ff3/structlog-25.4.0.tar.gz", hash = "sha256:186cd1b0a8ae762e29417095664adf1d6a31702160a46dacb7796ea82f7409e4", size = 1369138, upload-time = "2025-06-02T08:21:12.971Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/4a/97ee6973e3a73c74c8120d59829c3861ea52210667ec3e7a16045c62b64d/structlog-25.4.0-py3-none-any.whl", hash = "sha256:fe809ff5c27e557d14e613f45ca441aabda051d119ee5a0102aaba6ce40eed2c", size = 68720, upload-time = "2025-06-02T08:21:11.43Z" },
+]


### PR DESCRIPTION
## Summary

- Fixed UVManager.check_updates() to return (False, 0) instead of (True, 0)
- Fixed LazyNvimManager.check_updates() to return (False, 0) instead of (True, 0) 
- Fixed FisherManager.check_updates() to return (False, 0) instead of (True, 0)
- Enhanced logging in check_all() and UvToolsManager for better debugging

## Problem Solved

Addresses issue #20: pkgstatus/swman was incorrectly installing packages on shell startup instead of just checking for updates. The root cause was inconsistent return values in check_updates() methods returning (True, 0) which created confusion about whether updates were available.

## Changes Made

1. **UVManager.check_updates()**: Now returns (False, 0) conservatively since UV doesn't provide a reliable check-only mode
2. **LazyNvimManager.check_updates()**: Returns (False, 0) to prevent unwanted plugin installations during checks
3. **FisherManager.check_updates()**: Returns (False, 0) to prevent unwanted Fish plugin installations during checks  
4. **Enhanced logging**: Added comprehensive logging to check_all() and individual managers for debugging

## Test Results

Before fix: `swman --check --json` showed inconsistent (True, 0) values
After fix: Shows proper (False, 0) for managers without reliable check modes, and real data like (True, 52) for pacman

## Impact

- Shell startup via `pkgstatus --quiet` no longer triggers unwanted installations
- Check operations remain truly read-only
- Actual update operations (swman --all) continue to work correctly
- Improved debugging capability through enhanced logging

Resolves #20