### PR TITLE
feat: split logging_config.py into separate logging and output modules

### DIFF
--- a/src/dotfiles/init.py
+++ b/src/dotfiles/init.py
@@ -14,8 +14,8 @@ from .logging_config import (
     setup_logging,
     bind_context,
     LoggingHelpers,
-    ConsoleOutput,
 )
+from .output_formatting import ConsoleOutput
 
 
 def expand(path):

--- a/src/dotfiles/logging_config.py
+++ b/src/dotfiles/logging_config.py
@@ -2,7 +2,7 @@
 Shared logging configuration for all dotfiles Python tools.
 
 Provides structured JSON logging to rotating files with context support.
-Logs go to files only - use Rich console for user interaction.
+Logs go to files only - use output_formatting module for user interaction.
 """
 
 import logging
@@ -11,16 +11,6 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 import structlog
-from rich.console import Console
-from rich.progress import (
-    Progress,
-    SpinnerColumn,
-    TextColumn,
-    BarColumn,
-    TaskProgressColumn,
-)
-from rich.table import Table
-from rich import print as rich_print
 
 
 def setup_logging(script_name: str) -> structlog.BoundLogger:
@@ -238,80 +228,3 @@ class LoggingHelpers:
             success=success,
             **context,
         )
-
-
-# Global console instance for consistent styling
-console = Console()
-
-
-class ConsoleOutput:
-    """
-    Rich-based console output abstraction that replaces print statements.
-
-    Provides consistent styling and formatting across all tools.
-    """
-
-    def __init__(self, verbose: bool = True, quiet: bool = False):
-        self.verbose = verbose
-        self.quiet = quiet
-        self.console = console
-
-    def status(self, message: str, emoji: str = "🔍") -> None:
-        """Display a status message with emoji."""
-        if not self.quiet:
-            self.console.print(f"{emoji} {message}")
-
-    def success(self, message: str, emoji: str = "✅") -> None:
-        """Display a success message."""
-        if not self.quiet:
-            self.console.print(f"{emoji} {message}", style="green")
-
-    def error(self, message: str, emoji: str = "❌") -> None:
-        """Display an error message."""
-        if not self.quiet:
-            self.console.print(f"{emoji} {message}", style="red")
-
-    def warning(self, message: str, emoji: str = "⚠️") -> None:
-        """Display a warning message."""
-        if not self.quiet:
-            self.console.print(f"{emoji} {message}", style="yellow")
-
-    def info(self, message: str, emoji: str = "💡") -> None:
-        """Display an info message."""
-        if not self.quiet and self.verbose:
-            self.console.print(f"{emoji} {message}", style="blue")
-
-    def header(self, title: str, emoji: str = "📊") -> None:
-        """Display a section header."""
-        if not self.quiet:
-            self.console.print(f"\n{emoji} {title}", style="bold cyan")
-            self.console.print("=" * (len(title) + 3))
-
-    def table(self, title: str, columns: list, rows: list, emoji: str = "📋") -> None:
-        """Display a formatted table."""
-        if not self.quiet:
-            table = Table(title=f"{emoji} {title}")
-
-            for column in columns:
-                table.add_column(column, style="cyan")
-
-            for row in rows:
-                table.add_row(*[str(cell) for cell in row])
-
-            self.console.print(table)
-
-    def progress_context(self):
-        """Return a Rich progress context for long operations."""
-        return Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            BarColumn(),
-            TaskProgressColumn(),
-            console=self.console,
-            disable=self.quiet,
-        )
-
-    def json(self, data) -> None:
-        """Pretty print JSON data."""
-        if not self.quiet:
-            rich_print(data)

--- a/src/dotfiles/output_formatting.py
+++ b/src/dotfiles/output_formatting.py
@@ -1,0 +1,94 @@
+"""
+Rich-based console output formatting for dotfiles Python tools.
+
+Provides consistent styling and formatting across all tools.
+Separated from logging to maintain single responsibility principle.
+"""
+
+from rich.console import Console
+from rich.progress import (
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+    BarColumn,
+    TaskProgressColumn,
+)
+from rich.table import Table
+from rich import print as rich_print
+
+
+# Global console instance for consistent styling
+console = Console()
+
+
+class ConsoleOutput:
+    """
+    Rich-based console output abstraction that replaces print statements.
+
+    Provides consistent styling and formatting across all tools.
+    """
+
+    def __init__(self, verbose: bool = True, quiet: bool = False):
+        self.verbose = verbose
+        self.quiet = quiet
+        self.console = console
+
+    def status(self, message: str, emoji: str = "🔍") -> None:
+        """Display a status message with emoji."""
+        if not self.quiet:
+            self.console.print(f"{emoji} {message}")
+
+    def success(self, message: str, emoji: str = "✅") -> None:
+        """Display a success message."""
+        if not self.quiet:
+            self.console.print(f"{emoji} {message}", style="green")
+
+    def error(self, message: str, emoji: str = "❌") -> None:
+        """Display an error message."""
+        if not self.quiet:
+            self.console.print(f"{emoji} {message}", style="red")
+
+    def warning(self, message: str, emoji: str = "⚠️") -> None:
+        """Display a warning message."""
+        if not self.quiet:
+            self.console.print(f"{emoji} {message}", style="yellow")
+
+    def info(self, message: str, emoji: str = "💡") -> None:
+        """Display an info message."""
+        if not self.quiet and self.verbose:
+            self.console.print(f"{emoji} {message}", style="blue")
+
+    def header(self, title: str, emoji: str = "📊") -> None:
+        """Display a section header."""
+        if not self.quiet:
+            self.console.print(f"\n{emoji} {title}", style="bold cyan")
+            self.console.print("=" * (len(title) + 3))
+
+    def table(self, title: str, columns: list, rows: list, emoji: str = "📋") -> None:
+        """Display a formatted table."""
+        if not self.quiet:
+            table = Table(title=f"{emoji} {title}")
+
+            for column in columns:
+                table.add_column(column, style="cyan")
+
+            for row in rows:
+                table.add_row(*[str(cell) for cell in row])
+
+            self.console.print(table)
+
+    def progress_context(self):
+        """Return a Rich progress context for long operations."""
+        return Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            TaskProgressColumn(),
+            console=self.console,
+            disable=self.quiet,
+        )
+
+    def json(self, data) -> None:
+        """Pretty print JSON data."""
+        if not self.quiet:
+            rich_print(data)

--- a/src/dotfiles/pkgstatus.py
+++ b/src/dotfiles/pkgstatus.py
@@ -15,7 +15,8 @@ from pathlib import Path
 from typing import Dict, Optional
 
 import click
-from .logging_config import setup_logging, bind_context, LoggingHelpers, ConsoleOutput
+from .logging_config import setup_logging, bind_context, LoggingHelpers
+from .output_formatting import ConsoleOutput
 
 
 @dataclass

--- a/src/dotfiles/swman.py
+++ b/src/dotfiles/swman.py
@@ -19,7 +19,8 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 import click
-from .logging_config import setup_logging, bind_context, LoggingHelpers, ConsoleOutput
+from .logging_config import setup_logging, bind_context, LoggingHelpers
+from .output_formatting import ConsoleOutput
 
 
 def run_with_streaming_output(


### PR DESCRIPTION
## Summary

Split the responsibility of `logging_config.py` into two focused modules following the single responsibility principle.

### Changes Made

- **Created `output_formatting.py`** - New dedicated module containing:
  - `ConsoleOutput` class for Rich-based console output
  - All Rich dependencies (Console, Progress, Table, etc.)
  - Focused solely on output presentation

- **Updated `logging_config.py`** - Cleaned up to focus only on logging:
  - Removed all output-related code (`ConsoleOutput` class)
  - Removed Rich dependencies for console output
  - Kept only logging functionality (structlog, file handlers, LoggingHelpers)

- **Updated all Python scripts** to use the new module structure:
  - `init.py` - Updated imports to use both modules
  - `swman.py` - Updated imports to use both modules  
  - `pkgstatus.py` - Updated imports to use both modules

### Benefits

- **Single Responsibility Principle**: Each module now has a clear, focused purpose
- **Better Organization**: Logging and output concerns are properly separated
- **Maintainability**: Easier to maintain and extend each module independently
- **No Breaking Changes**: All existing functionality works exactly the same

## Test plan

- [x] All compilation tests pass (`make test-compile`)
- [x] Pre-commit hooks pass
- [x] All entry points work correctly (`dotfiles-init --help`, `dotfiles-swman --help`, `dotfiles-pkgstatus --help`)
- [x] Maintains full backward compatibility
- [x] No functional changes to existing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)