### PR TITLE
feat: implement automatic SSH key loading via symlink (issue #19)

### DIFF
--- a/fish/conf.d/fish-ssh-agent.fish
+++ b/fish/conf.d/fish-ssh-agent.fish
@@ -6,10 +6,14 @@ if not __ssh_agent_is_started
     __ssh_agent_start
 end
 
-# Auto-load environment-specific SSH key
-if test -n "$DOTFILES_ENVIRONMENT"
-    set ssh_key_path $HOME/.ssh/id_ed25519_(hostname)_$DOTFILES_ENVIRONMENT
-    if test -f $ssh_key_path
-        ssh-add $ssh_key_path 2>/dev/null
+# Auto-load default SSH key (symlink created by init script)
+set default_key_path $HOME/.ssh/id_ed25519_default
+if test -f $default_key_path
+    # Check if key is already loaded to avoid duplicates
+    if not ssh-add -l | grep -q $default_key_path
+        ssh-add $default_key_path 2>/dev/null
+        if test $status -eq 0
+            echo "✅ SSH key loaded: id_ed25519_default"
+        end
     end
 end

--- a/src/dotfiles/init.py
+++ b/src/dotfiles/init.py
@@ -534,6 +534,18 @@ class Linux:
             self.run_command_with_error_handling(
                 ["ssh-add", current_key], logger, "Add SSH key to agent"
             )
+
+            # Create default SSH key symlink for automatic loading
+            default_key_link = expand("~/.ssh/id_ed25519_default")
+            if not exists(default_key_link):
+                try:
+                    os.symlink(current_key, default_key_link)
+                    print(
+                        f"✅ Created SSH key symlink: id_ed25519_default -> {os.path.basename(current_key)}"
+                    )
+                except OSError as e:
+                    print(f"⚠️  WARNING: Could not create SSH key symlink: {e}")
+
             key_name = f'"{socket.gethostname()} {self.environment}"'
             self.run_command_with_error_handling(
                 ["/usr/bin/gh", "ssh-key", "add", f"{current_key}.pub", "-t", key_name],


### PR DESCRIPTION
## Summary

Implements a simple symlink-based approach for automatic SSH key loading in Fish shell, replacing the complex environment-dependent approach originally planned.

- Creates `~/.ssh/id_ed25519_default` symlink pointing to environment-specific key
- Simplifies Fish SSH agent configuration to use the default symlink
- Eliminates dependency on environment variables in shell scripts

## Changes

- **`src/dotfiles/init.py`**: Added symlink creation in `link_accounts()` method after SSH key generation
- **`fish/conf.d/fish-ssh-agent.fish`**: Simplified to load default SSH key via symlink instead of environment-dependent logic

## Test plan

- [ ] Verify SSH key symlink is created during init process
- [ ] Confirm Fish shell automatically loads SSH key on startup
- [ ] Test that duplicate key loading is prevented
- [ ] Validate pre-commit checks pass
- [ ] Run compilation tests

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)